### PR TITLE
Add capybara and selenium webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'http://rubygems.org'
 gem 'cucumber'
+gem 'capybara'
+gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,20 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
     backports (3.12.0)
     builder (3.2.3)
+    capybara (3.13.2)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     cucumber (3.1.2)
       builder (>= 2.1.2)
       cucumber-core (~> 3.2.0)
@@ -20,15 +32,33 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
+    ffi (1.10.0)
     gherkin (5.1.0)
+    mini_mime (1.0.1)
+    mini_portile2 (2.4.0)
     multi_json (1.13.1)
     multi_test (0.1.2)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    public_suffix (3.0.3)
+    rack (2.0.6)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    regexp_parser (1.3.0)
+    rubyzip (1.2.2)
+    selenium-webdriver (3.141.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2, >= 1.2.2)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   cucumber
+  selenium-webdriver
 
 BUNDLED WITH
    2.0.1

--- a/README.md
+++ b/README.md
@@ -18,3 +18,6 @@ Run a single feature -
 
 `bundle exec cucumber features/my_feature.feature`
 
+## Environments
+
+Currently the tests are configured to run against the Test environment, this environment is only accessible when inside the MoJ network. (http://portal.tst.legalservices.gov.uk)

--- a/features/example.feature
+++ b/features/example.feature
@@ -1,5 +1,0 @@
-Feature: CWA
-
-Scenario: Happy
-  When I use CW
-  And I am happy

--- a/features/step_definitions/example_steps.rb
+++ b/features/step_definitions/example_steps.rb
@@ -1,7 +1,0 @@
-When("I use CW") do
-  
-end
-
-When("I am happy") do
-  true
-end

--- a/features/step_definitions/portal_login_steps.rb
+++ b/features/step_definitions/portal_login_steps.rb
@@ -1,5 +1,5 @@
 When('I visit the portal url') do
-  visit('http://portal.stg.legalservices.gov.uk')
+  visit('http://portal.tst.legalservices.gov.uk')
 end
 
 Then('I see the portal login page') do

--- a/features/step_definitions/portal_login_steps.rb
+++ b/features/step_definitions/portal_login_steps.rb
@@ -1,0 +1,7 @@
+When('I visit the portal url') do
+  visit('http://portal.stg.legalservices.gov.uk')
+end
+
+Then('I see the portal login page') do
+  page.has_content?('To sign in to the Online Portal')
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,3 @@
-Before do |scenario|
-  puts "I'm running"
-end
+require 'capybara/cucumber'
+
+Capybara.default_driver = :selenium

--- a/features/valid_pa_ap.feature
+++ b/features/valid_pa_ap.feature
@@ -1,0 +1,5 @@
+Feature: Test Valid PA and AP codes
+
+Scenario: Visit the Portal
+  When I visit the portal url
+  Then I see the portal login page

--- a/features/valid_procurement_area_access_point.feature
+++ b/features/valid_procurement_area_access_point.feature
@@ -1,4 +1,4 @@
-Feature: Test Valid PA and AP codes
+Feature: Test Valid Procurement Area and Access Point codes
 
 Scenario: Visit the Portal
   When I visit the portal url


### PR DESCRIPTION
I have added the whole team to the PR as I think it would be beneficial for everyone to follow along and have an input in this.  Let's all try to keep PRs on this short, and with full explanations of what we are doing so that it is easy for people new to Ruby and testing to follow along with this spike/test.

Here we add the cabybara gem by following the instructions here - 
https://github.com/teamcapybara/capybara
This works with cucumber and gives us helpful methods like visiting a web page or clicking a button that can be used in our steps file.

We need the selenium-webdriver gem to interact with our web browser and perform the actions we want to do.

To test that these gems are working correctly, we have a feature and steps to visit the portal url in stage environment and check that we are on the login page.

Example files to check functionality from the first PR have been deleted.

In the next PR I will add a README.md and instructions on how to run the tests.

