### PR TITLE
Add log in scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Run a single feature -
 
 `bundle exec cucumber features/my_feature.feature`
 
-## Environments
+## Environments and users
 
 Currently the tests are configured to run against the Test environment, this environment is only accessible when inside the MoJ network. (http://portal.tst.legalservices.gov.uk)
+
+The log in test logs in using the USERNAME and PASSWORD environment
+variables which you should set before running the test.  You also need to ensure that the user exists in the test environment.
+
+```
+export USERNAME=test
+export PASSWORD=password
+```

--- a/features/step_definitions/portal_login_steps.rb
+++ b/features/step_definitions/portal_login_steps.rb
@@ -5,3 +5,18 @@ end
 Then('I see the portal login page') do
   page.has_content?('To sign in to the Online Portal')
 end
+
+Given('user is on the portal login page') do
+  visit('http://portal.tst.legalservices.gov.uk')
+  page.has_content?('To sign in to the Online Portal')
+end
+
+When('user Logs in') do
+  fill_in 'username', with: ENV['USERNAME']
+  fill_in 'password', with: ENV['PASSWORD']
+  click_button 'Log in'
+end
+
+Then('Portal application page is displayed') do
+  page.has_content?('Welcome to the Online Portal.')
+end

--- a/features/valid_procurement_area_access_point.feature
+++ b/features/valid_procurement_area_access_point.feature
@@ -3,3 +3,8 @@ Feature: Test Valid Procurement Area and Access Point codes
 Scenario: Visit the Portal
   When I visit the portal url
   Then I see the portal login page
+
+Scenario: Log in to Portal
+  Given user is on the portal login page
+  When user Logs in 
+  Then Portal application page is displayed


### PR DESCRIPTION
Paired with Ravi and Joe to create a scenario for logging into the portal

The new scenario logs in using the USERNAME and PASSWORD environment
variables which you should set before running the test.
```
export USERNAME=test
export PASSWORD=password
```
These variables should match an existing user in the test Portal.

Once the user is logged we check that the portal application home page
is displayed.

Co-authored-by: Ravi Penumarthy <ravi.penumarthy@justice.gov.uk>
Co-authored-by: Joe Giffin <joe.giffin@justice.gov.uk>