### PR TITLE
After hook for logging out of portal

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,3 @@
+After do
+  visit('https://portal.tst.legalservices.gov.uk/oam/server/logout?')
+end


### PR DESCRIPTION
There are a maximum number of sessions allowed for a particular user on
the portal, if we exceed this number then the user will not be allowed
to access the portal again.  We can clear the session with the portal by
logging out.  This change adds an after hook so that the log out page is
always called.