### PR TITLE
Log into CWA

### DIFF
--- a/features/step_definitions/portal_login_steps.rb
+++ b/features/step_definitions/portal_login_steps.rb
@@ -20,3 +20,26 @@ end
 Then('Portal application page is displayed') do
   expect(page).to have_content('Welcome to the Online Portal.')
 end
+
+Given('user is on the portal home page') do
+  steps %(
+    Given user is on the portal login page
+    When user Logs in
+    Then Portal application page is displayed
+  )
+end
+
+When('user clicks on CWA link') do
+  new_window = window_opened_by { click_link('Contracted Work and Administration (CWA)') }
+  within_window new_window do
+    # Force capybara to wait until the page has loaded before continuing
+    page.has_selector?('h1')
+  end
+end
+
+Then('CWA application page is displayed') do
+  cwa_window = switch_to_window { page.title == 'Oracle Applications Home Page' }
+  within_window cwa_window do
+    expect(page).to have_content('Navigator')
+  end
+end

--- a/features/valid_procurement_area_access_point.feature
+++ b/features/valid_procurement_area_access_point.feature
@@ -8,3 +8,8 @@ Scenario: Log in to Portal
   Given user is on the portal login page
   When user Logs in 
   Then Portal application page is displayed
+
+Scenario: Log in to CWA
+  Given user is on the portal home page
+  When user clicks on CWA link
+  Then CWA application page is displayed


### PR DESCRIPTION
Add feature to log into CWA, we reuse the existing steps to log into the
portal and view the portal homepage, then we click on the CWA link.

We had to add a page.has_selector? query to wait for the page to load,
otherwise the next step would fail as the CWA window hadn't loaded yet.

Once the page is loaded we switch to that window and check that the page
has the required content.

Co-authored-by: Ravi Penumarthy <ravi.penumarthy@justice.gov.uk>