### PR TITLE
Open a provider submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,18 @@ Run a single feature -
 Currently the tests are configured to run against the Test environment, this environment is only accessible when inside the MoJ network. (http://portal.tst.legalservices.gov.uk)
 
 The log in test logs in using the USERNAME and PASSWORD environment
-variables which you should set before running the test.  You also need to ensure that the user exists in the test environment.
+variables which you should set before running the test.  You also need to ensure that the user exists in the test environment.  
+
+For the CWA open provider submission feature you will need to set the firm details as well.  
+
+Examples of values given below, please note value must match data already present in the environment.
 
 ```
 export USERNAME=test
 export PASSWORD=password
+export FIRMNAME="EXAMPLE SOLICITORS"
+export ACCOUNT_NUMBER=0A123B
+export PERIOD=DEC-2010
+export AREA_OF_LAW="LEGAL HELP"
+export SUBMISSION_REF=0A123B/11.2
 ```

--- a/features/open_provider_submission.feature
+++ b/features/open_provider_submission.feature
@@ -1,0 +1,6 @@
+Feature: Open a providers submission
+
+Scenario: Open a providers submission
+  Given user is on the sumission search page
+  When user searches for their provider submission
+  Then their submission details are displayed

--- a/features/step_definitions/cwa_navigation_steps.rb
+++ b/features/step_definitions/cwa_navigation_steps.rb
@@ -16,3 +16,30 @@ end
 Then('Submission Search Page displayed') do
   expect(page).to have_content('Submission Search')
 end
+
+Given('user is on the sumission search page') do
+  steps %(
+    Given user is on the portal login page
+    When user Logs in
+    Then Portal application page is displayed
+    When user clicks on CWA link
+    Then CWA application page is displayed
+    When user navigates to Submissions page
+    Then Submission Search Page displayed
+  )
+end
+
+When('user searches for their provider submission') do
+  fill_in 'SearchFirmName', with: ENV['FIRMNAME']
+  fill_in 'SearchLscAccountNo', with: ENV['ACCOUNTNUMBER']
+  fill_in 'SearchOfficeName', with: ENV['FIRMNAME']
+  page.select ENV['AREA_OF_LAW'], from: 'AreaOfLawSearch'
+  fill_in 'SearchSubmissionPeriod', with: ENV['PERIOD']
+  click_button 'Go'
+  expect(page).to have_content(ENV['SUBMISSION_REF'])
+  click_link 'N3:Update:0'
+end
+
+Then('their submission details are displayed') do
+  expect(page.title).to eq('Submission Details')
+end


### PR DESCRIPTION
Created a new feature file - open_provider_submission.feature
We reused the existing steps to get to the submission search page, then
entered the provider details to search for.

Set the following environment variables to target a submission -
FIRM_NAME
ACCOUNT_NUMBER
PERIOD
AREA_OF_LAW
SUBMISSION_REF

This is a short term solution, we need to start passing in test data via
a file.

Co-authored-by: Ravi Penumarthy <ravi.penumarthy@justice.gov.uk>
Co-authored-by: Michael Blatherwick <michael.blatherwick@digital.justice.gov.uk>