### PR TITLE
Refactor outcome page fill into module

### DIFF
--- a/features/pages/outcome_page.rb
+++ b/features/pages/outcome_page.rb
@@ -1,0 +1,82 @@
+module OutcomePage
+
+  def add_outcome(values, page)
+    puts 'add_outcome method'
+    page.click_button 'AddOutcome'
+    page.fill_in 'MatterType', with: values[:matter_type]
+    matter_type = page.find_by_id('MatterType')
+    matter_type.send_keys :tab
+    # Schedule Reference
+    page.find_by_id('LinesDFF3', wait: 5)
+    page.fill_in 'LinesDFF3', with: values[:submission_reference]
+    # Case ref number
+    page.fill_in 'LinesDFF4', with: values[:case_ref_number]
+    # Case Start Date	
+    page.fill_in 'LinesDFF5', with: values[:case_start_date]
+    # Case ID
+    page.fill_in 'LinesDFF6', with: values[:case_id]
+    # Procurement Area
+    page.fill_in 'LinesDFF7', with: values[:procurement_area]
+    procurement_area = page.find_by_id('LinesDFF7')
+    procurement_area.send_keys :tab
+    # Access Point
+    page.fill_in 'LinesDFF8', with: values[:access_point]
+    # Client Forename
+    page.fill_in 'LinesDFF10', with: values[:client_forename]
+    # Client Surname
+    page.fill_in 'LinesDFF11', with: values[:client_surname]
+    # Client DOB
+    page.fill_in 'LinesDFF12', with: values[:client_dob]
+    # UCN
+    sleep(2) #TODO find better way than sleep
+    page.fill_in 'LinesDFF13', with: values[:ucn]
+    # Postal application accepted
+    page.select values[:postal_application_accepted], from: 'LinesDFF14'
+    # Gender
+    page.select values[:gender], from: 'LinesDFF15'
+    # Ethnicity
+    page.select values[:ethnicity], from: 'LinesDFF16'
+    # Disability
+    page.select values[:disability], from: 'LinesDFF17'
+    # Postcode
+    page.fill_in 'LinesDFF18', with: values[:postcode]
+    # Case concluded date
+    page.fill_in 'LinesDFF19', with: values[:case_concluded_date]
+    # Advice time
+    page.fill_in 'LinesDFF20', with: values[:advice_time]
+    # Travel time
+    page.fill_in 'LinesDFF21', with: values[:travel_time]
+    # Waiting Time
+    page.fill_in 'LinesDFF22', with: values[:waiting_time]
+    # Profit costs excluding VAT
+    page.fill_in 'LinesDFF23', with: values[:profit_costs_excluding_vat]
+    # Disbursements excluding VAT
+    page.fill_in 'LinesDFF24', with: values[:disbursements_excluding_vat]
+    # Counsel costs excluding VAT
+    page.fill_in 'LinesDFF25', with: values[:counsel_costs_excluding_vat]
+    # Disbursements VAT amount
+    page.fill_in 'LinesDFF26', with: values[:disbursements_vat_amount]
+    # Profit and Counsel VAT Indicator
+    page.select values[:profit_and_counsel_vat_indicator], from: 'LinesDFF27'
+    # London Rate
+    page.select values[:london_rate], from: 'LinesDFF28'
+    # Travel and Waiting costs excluding VAT
+    page.fill_in 'LinesDFF29', with: values[:travel_and_waiting_costs_excluding_vat]
+    # Value of Costs/Damages awarded
+    page.fill_in 'LinesDFF30', with: values[:value_of_costs_damages_awarded]
+    # Local authority number
+    page.fill_in 'LinesDFF31', with: values[:local_authority_number]
+    # Client Type
+    page.select values[:client_type], from: 'LinesDFF32'
+    # Stage Reached
+    # Outcome for client
+    page.select values[:outcome_for_client], from: 'LinesDFF34'
+    # Case stage level
+    page.select values[:case_stage_level], from: 'LinesDFF35'
+    # Exemption Criteria Satisfied
+    page.select values[:exemption_criteria_satisfied], from: 'LinesDFF36'
+    # Exceptional case funding Ref
+    # Transfer date
+    page.click_button 'Apply_uixr'
+  end
+end

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -1,4 +1,7 @@
-Given("user is on their sumission details page") do
+require_relative '../pages/outcome_page.rb'
+include OutcomePage
+
+Given('user is on their sumission details page') do
   steps %(
     Given user is on the portal login page
     When user Logs in
@@ -12,83 +15,43 @@ Given("user is on their sumission details page") do
   )
 end
 
-When("user adds a valid outcome") do
-  click_button 'AddOutcome'
-  fill_in 'MatterType', with: 'FAMA:FADV'
-  matter_type = page.find_by_id('MatterType')
-  matter_type.send_keys :tab
-  # Schedule Reference
-  page.find_by_id('LinesDFF3', wait: 5)
-  fill_in 'LinesDFF3', with: ENV['SUBMISSION_REF']
-  # Case ref number
-  fill_in 'LinesDFF4', with: 'TestCaseRef'
-  # Case Start Date	
-  fill_in 'LinesDFF5', with: '01-Jul-2019'
-  # Case ID
-  fill_in 'LinesDFF6', with: '001'
-  # Procurement Area
-  fill_in 'LinesDFF7', with: 'PA00002'
-  procurement_area = page.find_by_id('LinesDFF7')
-  procurement_area.send_keys :tab
-  # Access Point
-  fill_in 'LinesDFF8', with: 'AP00000'
-  # Client Forename
-  fill_in 'LinesDFF10', with: 'Test'
-  # Client Surname
-  fill_in 'LinesDFF11', with: 'Person'
-  # Client DOB
-  fill_in 'LinesDFF12', with: '01-May-1980'
-  # UCN
-  page.find_by_id 'LinesDFF13'  
-  fill_in 'LinesDFF13', with: '01051980/T/PERS'
-  # Postal application accepted
-  page.select 'N', from: 'LinesDFF14'
-  # Gender
-  page.select 'Male', from: 'LinesDFF15'
-  # Ethnicity
-  page.select '00-Other', from: 'LinesDFF16'
-  # Disability
-  page.select 'NCD-Not Considered Disabled', from: 'LinesDFF17'
-  # Postcode
-  fill_in 'LinesDFF18', with: 'SW1H 9AJ'
-  # Case concluded date
-  fill_in 'LinesDFF19', with: '05-Jul-2019'
-  # Advice time
-  fill_in 'LinesDFF20', with: '0'
-  # Travel time
-  fill_in 'LinesDFF21', with: '0'
-  # Waiting Time
-  fill_in 'LinesDFF22', with: '0'
-  # Profit costs excluding VAT
-  fill_in 'LinesDFF23', with: '100.00'
-  # Disbursements excluding VAT
-  fill_in 'LinesDFF24', with: '0'
-  # Counsel costs excluding VAT
-  fill_in 'LinesDFF25', with: '0'
-  # Disbursements VAT amount
-  fill_in 'LinesDFF26', with: '0'
-  # Profit and Counsel VAT Indicator
-  page.select 'No', from: 'LinesDFF27'
-  # London Rate
-  page.select 'No', from: 'LinesDFF28'
-  # Travel and Waiting costs excluding VAT
-  fill_in 'LinesDFF29', with: '0'
-  # Value of Costs/Damages awarded
-  fill_in 'LinesDFF30', with: '0'
-  # Local authority number
-  fill_in 'LinesDFF31', with: '1234'
-  # Client Type
-  page.select 'P-Parent', from: 'LinesDFF32'
-  # Stage Reached
-  # Outcome for client
-  page.select 'FF-Settlement with no benefit for the client', from: 'LinesDFF34'
-  # Case stage level
-  page.select 'FPL01-Priv', from: 'LinesDFF35'
-  # Exemption Criteria Satisfied
-  page.select 'DV001', from: 'LinesDFF36'
-  # Exceptional case funding Ref
-  # Transfer date
-  click_button 'Apply_uixr'
+When('user adds a valid outcome') do
+  values = {
+    matter_type: 'FAMA:FADV',
+    submission_reference: ENV['SUBMISSION_REF'],
+    case_ref_number: 'TestCaseRef',
+    case_start_date: '01-Jul-2019',
+    case_id: '001',
+    procurement_area: 'PA00002',
+    access_point: 'AP00000',
+    client_forename: 'Test',
+    client_surname: 'Person',
+    client_dob: '01-May-1980',
+    ucn: '01051980/T/PERS',
+    postal_application_accepted: 'N',
+    gender: 'Male',
+    ethnicity: '00-Other',
+    disability: 'NCD-Not Considered Disabled',
+    postcode: 'SW1H 9AJ',
+    case_concluded_date: '05-Jul-2019',
+    advice_time: '0',
+    travel_time: '0',
+    waiting_time: '0',
+    profit_costs_excluding_vat: '100.00',
+    disbursements_excluding_vat: '0',
+    counsel_costs_excluding_vat: '0',
+    disbursements_vat_amount: '0',
+    profit_and_counsel_vat_indicator: 'No',
+    london_rate: 'No',
+    travel_and_waiting_costs_excluding_vat: '0',
+    value_of_costs_damages_awarded: '0',
+    local_authority_number: '1234',
+    client_type: 'P-Parent',
+    outcome_for_client: 'FF-Settlement with no benefit for the client',
+    case_stage_level: 'FPL01-Priv',
+    exemption_criteria_satisfied: 'DV001'
+  }
+  OutcomePage.add_outcome(values, page)
 end
 
 Then('the outcome saves sucessfully') do


### PR DESCRIPTION
We want to test the unhappy path and other senarios, this would involve
a lot of duplicate code so we have refactored the add outcome step to
another method.  Then we simply pass in a hash of values from the step,
this way our step file is much cleaner and duplicate code is reduced.

Co-authored-by: Ravi Penumarthy <ravi.penumarthy@justice.gov.uk>