### PR TITLE
Add the unhappy path

### DIFF
--- a/features/add_outcome.feature
+++ b/features/add_outcome.feature
@@ -1,6 +1,11 @@
-Feature: Add an outcome
+Feature: Check access point validation
 
-Scenario: Add a vaild outcome
+Scenario: Add an outcome with AP00000 after 1st July case start date
   Given user is on their sumission details page
   When user adds a valid outcome
   Then the outcome saves sucessfully
+
+Scenario: Add an outcome with AP00000 before 1st July case start date
+  Given user is on their sumission details page
+  When user adds a invalid outcome
+  Then the outcome does not save and gives an error

--- a/features/pages/outcome_page.rb
+++ b/features/pages/outcome_page.rb
@@ -19,6 +19,7 @@ module OutcomePage
     page.fill_in 'LinesDFF7', with: values[:procurement_area]
     procurement_area = page.find_by_id('LinesDFF7')
     procurement_area.send_keys :tab
+    sleep(2)
     # Access Point
     page.fill_in 'LinesDFF8', with: values[:access_point]
     # Client Forename

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -54,8 +54,53 @@ When('user adds a valid outcome') do
   OutcomePage.add_outcome(values, page)
 end
 
+When('user adds a invalid outcome') do
+  values = {
+    matter_type: 'FAMA:FADV',
+    submission_reference: ENV['SUBMISSION_REF'],
+    case_ref_number: 'TestCaseRef',
+    case_start_date: '01-Jun-2019',
+    case_id: '002',
+    procurement_area: 'PA00002',
+    access_point: 'AP00000',
+    client_forename: 'Test',
+    client_surname: 'Person',
+    client_dob: '01-May-1980',
+    ucn: '01051980/T/PERS',
+    postal_application_accepted: 'N',
+    gender: 'Male',
+    ethnicity: '00-Other',
+    disability: 'NCD-Not Considered Disabled',
+    postcode: 'SW1H 9AJ',
+    case_concluded_date: '05-Jun-2019',
+    advice_time: '0',
+    travel_time: '0',
+    waiting_time: '0',
+    profit_costs_excluding_vat: '100.00',
+    disbursements_excluding_vat: '0',
+    counsel_costs_excluding_vat: '0',
+    disbursements_vat_amount: '0',
+    profit_and_counsel_vat_indicator: 'No',
+    london_rate: 'No',
+    travel_and_waiting_costs_excluding_vat: '0',
+    value_of_costs_damages_awarded: '0',
+    local_authority_number: '1234',
+    client_type: 'P-Parent',
+    outcome_for_client: 'FF-Settlement with no benefit for the client',
+    case_stage_level: 'FPL01-Priv',
+    exemption_criteria_satisfied: 'DV001'
+  }
+  OutcomePage.add_outcome(values, page)
+end
+
 Then('the outcome saves sucessfully') do
   expect(page).to_not have_content('Error')
   expect(page).to_not have_content('Warning')
   expect(page).to have_content('010719/001')
+end
+
+Then('the outcome does not save and gives an error') do
+  expect(page).to have_content('Error')
+  expect(page).to have_content('The Category of Law, Procurement Area and Access Point combination that has been used is not valid for the date that has been recorded.')
+  expect(page).to_not have_content('010719/002')
 end


### PR DESCRIPTION
Here we change the case start date to before the 1st July and check that
we get the error and that the outcome is not saved.

Co-authored-by: Ravi Penumarthy <ravi.penumarthy@justice.gov.uk>