### PR TITLE
PA and AP validation feature

### DIFF
--- a/features/procurement_area_and_access_point_validation.feature
+++ b/features/procurement_area_and_access_point_validation.feature
@@ -1,0 +1,28 @@
+Feature: Check procurement area and access point validation
+
+Scenario Outline: Add an outcome sucessfully
+  Given user is on their sumission details page
+  When user adds a valid outcome with <case_id>, <case_start_date>, <procurement_area> and <access_point>
+  Then the outcome saves sucessfully
+
+Examples:
+  | case_id | case_start_date | procurement_area | access_point |
+  |    '001'|   '01-Jul-2019' |        'PA00002' |    'AP00000' |
+  |    '002'|   '05-Jul-2019' |        'PA00002' |    'AP00000' |
+  |    '003'|   '05-Jun-2019' |        'PA00002' |    'AP00002' |
+  |    '004'|   '05-Jul-2019' |        'PA00124' |    'AP00000' |
+  |    '005'|   '05-Jun-2019' |        'PA00124' |    'AP00113' |
+  |    '006'|   '05-Jun-2019' |        'PA00125' |    'AP00000' |
+
+Scenario Outline: Check it errors with invalid combinations
+  Given user is on their sumission details page
+  When user adds a valid outcome with <case_id>, <case_start_date>, <procurement_area> and <access_point>
+  Then the outcome does not save and gives an error
+
+Examples:
+  | case_id | case_start_date | procurement_area | access_point |
+  |    '007'|   '01-Jul-2019' |        'PA00002' |    'AP00002' |
+  |    '008'|   '05-Jun-2019' |        'PA00002' |    'AP00000' |
+  |    '009'|   '05-Jun-2019' |        'PA00124' |    'AP00000' |
+  |    '010'|   '05-Jul-2019' |        'PA00124' |    'AP00113' |
+  |    '011'|   '05-Jul-2019' |        'PA00127' |    'AP00115' |

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -93,6 +93,45 @@ When('user adds a invalid outcome') do
   OutcomePage.add_outcome(values, page)
 end
 
+When('user adds a valid outcome with {string}, {string}, {string} and {string}') do |case_id, case_start_date, procurement_area, access_point|
+  values = {
+    matter_type: 'FAMA:FADV',
+    submission_reference: ENV['SUBMISSION_REF'],
+    case_ref_number: 'TestCaseRef',
+    case_start_date: case_start_date,
+    case_id: case_id,
+    procurement_area: procurement_area,
+    access_point: access_point,
+    client_forename: 'Test',
+    client_surname: 'Person',
+    client_dob: '01-May-1980',
+    ucn: '01051980/T/PERS',
+    postal_application_accepted: 'N',
+    gender: 'Male',
+    ethnicity: '00-Other',
+    disability: 'NCD-Not Considered Disabled',
+    postcode: 'SW1H 9AJ',
+    case_concluded_date: '05-Jul-2019',
+    advice_time: '0',
+    travel_time: '0',
+    waiting_time: '0',
+    profit_costs_excluding_vat: '100.00',
+    disbursements_excluding_vat: '0',
+    counsel_costs_excluding_vat: '0',
+    disbursements_vat_amount: '0',
+    profit_and_counsel_vat_indicator: 'No',
+    london_rate: 'No',
+    travel_and_waiting_costs_excluding_vat: '0',
+    value_of_costs_damages_awarded: '0',
+    local_authority_number: '1234',
+    client_type: 'P-Parent',
+    outcome_for_client: 'FF-Settlement with no benefit for the client',
+    case_stage_level: 'FPL01-Priv',
+    exemption_criteria_satisfied: 'DV001'
+  }
+  OutcomePage.add_outcome(values, page)
+end
+
 Then('the outcome saves sucessfully') do
   expect(page).to_not have_content('Error')
   expect(page).to_not have_content('Warning')


### PR DESCRIPTION
Procurement area and access point validation feature added.
We use Cucumber senario outlines to pass in different values for the
case start date, procurement area and access points.  We are passing in
the case_id currently as we do not have any tear down yet which would
delete the created outcomes. This is needed as we would otherwise get
duplicate errors.  This will be fixed in future PRs.

Another thing I'd like to add is the ability to have a "default" outcome then just pass in values which are to be overwritten in the steps file.

Co-authored-by: Ravi Penumarthy <ravi.penumarthy@justice.gov.uk>