### PR TITLE
Fix broken test with ufn

### DIFF
--- a/features/procurement_area_and_access_point_validation.feature
+++ b/features/procurement_area_and_access_point_validation.feature
@@ -3,16 +3,16 @@ Feature: Check procurement area and access point validation
 Scenario Outline: Add an outcome sucessfully
   Given user is on their sumission details page
   When user adds a valid outcome with <case_id>, <case_start_date>, <procurement_area> and <access_point>
-  Then the outcome saves sucessfully
+  Then the outcome saves sucessfully with <ufn>
 
 Examples:
-  | case_id | case_start_date | procurement_area | access_point |
-  |    '001'|   '01-Jul-2019' |        'PA00002' |    'AP00000' |
-  |    '002'|   '05-Jul-2019' |        'PA00002' |    'AP00000' |
-  |    '003'|   '05-Jun-2019' |        'PA00002' |    'AP00002' |
-  |    '004'|   '05-Jul-2019' |        'PA00124' |    'AP00000' |
-  |    '005'|   '05-Jun-2019' |        'PA00124' |    'AP00113' |
-  |    '006'|   '05-Jun-2019' |        'PA00125' |    'AP00000' |
+  | case_id | case_start_date | procurement_area | access_point | ufn          |
+  |    '011'|   '01-Jul-2019' |        'PA00002' |    'AP00000' | '010719/011' |
+  |    '012'|   '05-Jul-2019' |        'PA00002' |    'AP00000' | '050719/012' |
+  |    '013'|   '05-Jun-2019' |        'PA00002' |    'AP00002' | '050619/013' |
+  |    '014'|   '05-Jul-2019' |        'PA00124' |    'AP00000' | '050719/014' |
+  |    '015'|   '05-Jun-2019' |        'PA00124' |    'AP00113' | '050619/015' |
+  |    '016'|   '05-Jun-2019' |        'PA00125' |    'AP00000' | '050619/016' |
 
 Scenario Outline: Check it errors with invalid combinations
   Given user is on their sumission details page
@@ -21,8 +21,8 @@ Scenario Outline: Check it errors with invalid combinations
 
 Examples:
   | case_id | case_start_date | procurement_area | access_point |
-  |    '007'|   '01-Jul-2019' |        'PA00002' |    'AP00002' |
-  |    '008'|   '05-Jun-2019' |        'PA00002' |    'AP00000' |
-  |    '009'|   '05-Jun-2019' |        'PA00124' |    'AP00000' |
-  |    '010'|   '05-Jul-2019' |        'PA00124' |    'AP00113' |
-  |    '011'|   '05-Jul-2019' |        'PA00127' |    'AP00115' |
+  |    '017'|   '01-Jul-2019' |        'PA00002' |    'AP00002' |
+  |    '018'|   '05-Jun-2019' |        'PA00002' |    'AP00000' |
+  |    '019'|   '05-Jun-2019' |        'PA00124' |    'AP00000' |
+  |    '020'|   '05-Jul-2019' |        'PA00124' |    'AP00113' |
+  |    '021'|   '05-Jul-2019' |        'PA00127' |    'AP00115' |

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -132,14 +132,13 @@ When('user adds a valid outcome with {string}, {string}, {string} and {string}')
   OutcomePage.add_outcome(values, page)
 end
 
-Then('the outcome saves sucessfully') do
+Then('the outcome saves sucessfully with {string}') do |ufn|
   expect(page).to_not have_content('Error')
   expect(page).to_not have_content('Warning')
-  expect(page).to have_content('010719/001')
+  expect(page).to have_content(ufn)
 end
 
 Then('the outcome does not save and gives an error') do
   expect(page).to have_content('Error')
   expect(page).to have_content('The Category of Law, Procurement Area and Access Point combination that has been used is not valid for the date that has been recorded.')
-  expect(page).to_not have_content('010719/002')
 end


### PR DESCRIPTION
The tests were breaking and giving false positives before as they were
checking for the same ufn(unique file number) number each time.

This amendment means that the ufn in the assertion must match that
generated by the specific outcome.