### PR TITLE
Delete added outcomes after a senario

### DIFF
--- a/features/add_outcome.feature
+++ b/features/add_outcome.feature
@@ -1,10 +1,12 @@
 Feature: Check access point validation
 
+@delete_outcome_after
 Scenario: Add an outcome with AP00000 after 1st July case start date
   Given user is on their sumission details page
   When user adds a valid outcome
   Then the outcome saves sucessfully
 
+@delete_outcome_after
 Scenario: Add an outcome with AP00000 before 1st July case start date
   Given user is on their sumission details page
   When user adds a invalid outcome

--- a/features/pages/outcome_page.rb
+++ b/features/pages/outcome_page.rb
@@ -80,4 +80,21 @@ module OutcomePage
     # Transfer date
     page.click_button 'Apply_uixr'
   end
+
+  def delete_all_outcomes
+    steps %(
+      Given user is on the portal login page
+      When user Logs in
+      Then Portal application page is displayed
+      When user clicks on CWA link
+      Then CWA application page is displayed
+      When user navigates to Submissions page
+      Then Submission Search Page displayed
+      When user searches for their provider submission
+      Then their submission details are displayed
+    )
+    page.click_link 'Select All'
+    page.click_button 'Delete'
+    page.click_button 'Yes'
+  end
 end

--- a/features/procurement_area_and_access_point_validation.feature
+++ b/features/procurement_area_and_access_point_validation.feature
@@ -1,5 +1,6 @@
 Feature: Check procurement area and access point validation
 
+@delete_outcome_after
 Scenario Outline: Add an outcome sucessfully
   Given user is on their sumission details page
   When user adds an outcome with <case_id>, <case_start_date>, <procurement_area> and <access_point>

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,10 @@
+require_relative '../pages/outcome_page.rb'
+include OutcomePage
+
+After('@delete_outcome_after') do
+  delete_all_outcomes
+end
+
 After do
   visit('https://portal.tst.legalservices.gov.uk/oam/server/logout?')
 end


### PR DESCRIPTION
Outcomes were being created but not deleted, meaning that the tests
would only run once sucessfully and then fail.  By deleting all of the
outcomes after the relevant senarios this ensures the test can be re
run.

To delete outcomes after a senario we include the @delete_outcome_after
tag to the start of the senario.

I did try to have the delete_all_outcomes method pick up from the end of
the previous senario, but couldn't get it to work in the same page
window. With more time this is something that could be looked into.  The
work around as it is currently takes a little longer to run as it logs
into the portal, navigates to the submission list, and then deletes the
outcomes.  But by doing it this way it does mean that it can be run from
any point in the tests and is not dependant on the current state.