### PR TITLE
Fix javascript error on CWA log in

### DIFF
--- a/features/step_definitions/cwa_login_steps.rb
+++ b/features/step_definitions/cwa_login_steps.rb
@@ -2,7 +2,7 @@ When('user clicks on CWA link') do
   new_window = window_opened_by { click_link('Contracted Work and Administration (CWA)') }
   within_window new_window do
     # Force capybara to wait until the page has loaded before continuing
-    page.has_selector?('h1')
+    page.has_xpath?('//*[@id="responsibilityRN"]/table/tbody')
   end
 end
 


### PR DESCRIPTION
Roughly every 1 in 5 times of running a test there would be a javascript
error.  This changes the page item to check for presence on to the
navigation table, ensuring the navigation table is there before we
continue.