### PR TITLE
Add code owners and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/laa-get-access-service-improvement

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## What does this pull request do?
+
+Please describe what you did.
+_Required._
+
+## Why make these changes?
+
+Please describe why the changes were needed.
+_Required._.
+
+## Checklist
+
+- [ ] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-XXX


### PR DESCRIPTION
## What does this pull request do?

Precisely what the title says.

Shamelessly copied from https://github.com/ministryofjustice/laa-cwa/commit/507961e811c7224bf6a348064a6b6de2540755d5.

## Why make these changes?

Speed up review process, make sure people know who owns this repo.

Closes #17.

## Checklist

- [ ] Provided link to a JIRA ticket: N/A

For review: @ministryofjustice/laa-get-access-service-improvement 