### PR TITLE
Raise an error when test submission is missing

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -72,7 +72,7 @@ module CWAProvider
       id, _ = ref.split('#').last
       submissions.find do |submission|
         submission.id.to_s == id
-      end
+      end || raise("Missing #{ref} test submission")
     end
   end
 


### PR DESCRIPTION
## What does this pull request do?

What the title says.

## Why make these changes?

Bulkload feature steps assume there will always be a configured test submission for each environment.

This might not always be true though, so raise a proper error immediately. This saves debugging time.

## Checklist

- [ ] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-XXX / NA

Closes #93.
