### PR TITLE
Improvements - handle popup alerts on man sub screen, ho_ucn val, class based approach to sub values, new env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,9 @@ For more information about the Headless mode please have a look at [this doc](ht
 An optional `DEBUG_FAILURES=true` env can be set to step with the debugger into failed
 scenarios with `byebug`. This can be useful to investigate the context of a failure,
 for instance to be able to look at the latest opened window or instance variables.
+
+### Removing Bulkload files
+
+An optional `BULKLOAD_TMP_DELETE=false` env can be set to ensure that any dynamically
+created bulkload files are not automatically deleted after feature tests have completed.
+These files are found in features\support\bulkload\fixtures\tmp.

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -33,5 +33,7 @@ end
 at_exit do
   tmp_path = File.expand_path(Helpers::Bulkload::TMP_DIR)
   tmp_files = Dir.glob("#{tmp_path}/*")
-  FileUtils.rm_f(tmp_files)
+  if ENV['BULKLOAD_TMP_DELETE'] == 'true'
+    FileUtils.rm_f(tmp_files)
+  end
 end

--- a/features/support/ui/immigration_outcome.rb
+++ b/features/support/ui/immigration_outcome.rb
@@ -1,0 +1,16 @@
+require File.expand_path('../outcome.rb', __FILE__)
+class ImmigrationOutcome < Outcome
+
+  def add_values (row)
+    #immigration specific defaults set here
+    @defaults[:home_office_ucn] = 'A9999999'
+    @defaults[:ho_interview] = '0'
+
+    #if certain defaults not passed maybe report error here?
+    row.each do |k, v|
+      @defaults[k.to_sym] = v
+    end
+
+  end
+
+end

--- a/features/support/ui/outcome.rb
+++ b/features/support/ui/outcome.rb
@@ -1,0 +1,51 @@
+class Outcome
+
+  attr_accessor :defaults
+
+  def initialize
+
+    @defaults = {
+      :matter_type => "IMLB:IOUT",
+      :claim_type => "Completed Matter Claim",
+      :schedule_reference => "",
+      :case_reference_number => "TestCaseRef",
+      :procurement_area => "PA00136",
+      :access_point => "AP00137",
+      :client_forename => "Test",
+      :client_surname => "Person",
+      :client_date_of_birth => '01-Nov-2015',
+      :ucn => '01112015/T/PERS',
+      :postal_application_accepted => 'N',
+      :gender => 'Male',
+      :ethnicity => '00-Other',
+      :disability => 'NCD-Not Considered Disabled',
+      :client_postcode => 'SW1H 9AJ',
+      :case_concluded_date => '01-Nov-2019',
+      :advice_time => '0',
+      :travel_time => '0',
+      :waiting_time => '0',
+      :profit_costs_excluding_vat => '100.00',
+      :disbursements_excluding_vat => '0',
+      :counsel_costs_excluding_vat => '0',
+      :disbursements_vat_amount => '0',
+      :profit_and_counsel_vat_indicator => 'No',
+      :legacy_case => 'No',
+      :ho_interview => '0',
+      :ait_hearing_centre => '16-Other',
+      :travel_and_waiting_costs_excluding_vat => '0',
+      :adjourned_hearing_fee => '0',
+      :detention_travel_and_waiting_costs_excluding_vat => '0',
+      :jr_form_filling_costs_excluding_vat => '0',
+      :cmrh_oral => '0',
+      :cmrh_telephone => '0',
+      :substantive_hearing => 'No',
+      :stage_reached => '',
+      :outcome_for_client => 'IX',
+      :exemption_criteria_satisfied => '',
+      :exceptional_case_funding_reference => '',
+      :case_id => ''
+    }
+
+  end
+
+end

--- a/features/validations/legal_help/immigration_and_asylum/asylum_validation_manual.feature
+++ b/features/validations/legal_help/immigration_and_asylum/asylum_validation_manual.feature
@@ -1,11 +1,11 @@
 Feature: Validation for Immigration and Asylum claims
 
 @delete_outcome_after @manual_submission @valid @irc
-Scenario Outline: Add valid Immigration and Asylum claims using Derwentside IRC
+Scenario: Add valid Immigration and Asylum claims using Derwentside IRC
     Given user is on their submission details page
-    When user adds an outcome for Immigration with "<case id>", "<mt>", "<ecs code>", "<ecf ref>", "<case start date>", "<pa>" and "<ap>"
-    Then the outcome saves successfully
-    Examples:
-        | case id | mt        | ecs code | ecf ref  | case start date | pa      | ap      |
-        | 001     | IAXL:IDAS |          |          | 01/11/19        | PA00188 | AP00186 |
-        | 002     | IAXL:IDAS |          |          | 01/11/19        | PA00188 | AP00187 |
+    When user adds outcomes for Immigration with fields like this:
+        | case_id | matter_type | case_start_date | pa      | ap      |
+        | 001     | IAXL:IDAS   | 01/11/19        | PA00188 | AP00186 |
+        | 002     | IAXL:IDAS   | 01/11/19        | PA00188 | AP00186 |
+        | 003     | IAXL:IDAS   | 01/11/19        | PA00188 | AP00186 |
+    Then the outcomes save successfully

--- a/features/validations/legal_help/immigration_and_asylum/ho_ucn_validation_manual.feature
+++ b/features/validations/legal_help/immigration_and_asylum/ho_ucn_validation_manual.feature
@@ -1,0 +1,23 @@
+Feature: Validation of Home Office UCN for Immigration and Asylum claims
+
+@delete_outcome_after @manual_submission @valid @ho_ucn
+Scenario: Add valid Immigration and Asylum claims using new HO_UCN format
+    Given user is on their submission details page
+    When user adds outcomes for Immigration with fields like this:
+    | case_id | matter_type | case_start_date | home_office_ucn   |
+    | 001     | IAXL:IDAS   | 01/11/19        | 12345678 |
+    | 002     | IAXL:IDAS   | 01/11/19        | ABCDEFGH |
+
+    Then the outcome saves successfully
+
+@delete_outcome_after @manual_submission @invalid @ho_ucn
+Scenario: Add valid Immigration and Asylum claims using new HO_UCN format
+    Given user is on their submission details page
+    When user adds outcomes for Immigration with fields like this:
+    | case_id | matter_type | case_start_date | home_office_ucn   |
+    | 001     | IAXL:IDAS   | 01/11/19        |                   |
+
+    Then the outcome does not save and this popup error appears:
+    """
+    A value must be entered for "Home Office UCN"
+    """

--- a/features/validations/legal_help/immigration_and_asylum/ho_ucn_validations.feature
+++ b/features/validations/legal_help/immigration_and_asylum/ho_ucn_validations.feature
@@ -1,0 +1,29 @@
+Feature: Immigration Bulk load validations
+
+  Background:
+    Given a test firm user is logged in CWA
+    And user prepares to submit outcomes for test provider "LEGAL HELP.IMMOT#6"
+
+  Scenario: Bulkload Civil Immigration outcomes with HO_UCN
+    Given the following Matter Types are chosen:
+      | IACC:IASY |
+    And the following outcomes are bulkloaded:
+      | # | CASE_START_DATE | HO_UCN |
+      | 1 | 01/04/2013      |        |
+      | 2 | 01/04/2013      | 1AAAAAAA1AAAAAAA1AAAAAAA |
+    Then the following results are expected:
+      | # | ERROR_CODE_OR_MESSAGE          |
+      | 1 | HO_UCN is missing              |
+      | 2 | Value :1AAAAAAA1AAAAAAA1AAAAAAA is not valid for : HO_UCN |
+
+  Scenario: Bulkload Civil Immigration outcomes with HO_UCN
+    Given the following Matter Types are chosen:
+      | IACC:IASY |
+    And the following outcomes are bulkloaded:
+      | # | CASE_START_DATE | HO_UCN   |
+      | 1 | 01/04/2013      | 1AAAAAAA |
+      | 2 | 01/04/2013      | 1AAAAAAA1AAAAAAA |
+    Then the following results are expected:
+      | # | ERROR_CODE_OR_MESSAGE |
+      | 1 | <none>                |
+      | 2 | <none>                |


### PR DESCRIPTION
## What does this pull request do?

Please describe what you did.
Spent an L&D day implementing a number of improvements.  
1. New steps to check for and test if a popup alert with some text appears on the man sub screen
2. New approach to testing man sub lines if they should all be successfully save - essentially we create then all 1 by 1  and then test they have saved, removing the need to individually remove them.  We instead can remove them at the end of the Scenario.
3. New bulkload envvar to allow a dev to persist the bulkload files to aid testing
4. New classes to encapsulate the default sub vals for outcomes with cats of law subclasses this i.e. Outcome->ImmigrationOutcome.  The Outcome here is specific to Legal Help (maybe should be called LegalHelpOutcome?).  New step definitions created to use them.
5. Refactored one test to make use of the approach in step 2 above.

## Why make these changes?
Some of these changes were linked to active work (i.e. HO_UCN), some had been raised as 'issues' a while ago, some are just my thinking about ideas which could help (or not?).

## Checklist

- [ ] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-
