### PR TITLE
TA-1366 create tests for popup messages (supporting ho_ucn features)

### DIFF
--- a/features/support/am/defaults/am_crime_lower_defaults.yml
+++ b/features/support/am/defaults/am_crime_lower_defaults.yml
@@ -1,0 +1,234 @@
+criminal_investigations:
+  criminal_investigations_base: &criminal_investigations_base
+    client_forename:
+    client_surname:
+    disability:
+    disbursements_amount:
+    disbursements_vat:
+    ethnicity:
+    gender:
+    profit_cost:
+    ufn:
+    vat_indicator:
+    work_concluded_date:
+
+  post_charge_attendance: &post_charge_attendance
+    <<: *criminal_investigations_base
+    dscc_number:
+    duty_solicitor:
+    no_of_police_station:
+    no_of_suspects:
+    police_station:
+    schedule_ref:
+    travel_costs:
+    travel_waiting_costs:
+    youth_court:
+
+  warrant_of_further_detention: &warrant_of_further_detention
+    <<: *criminal_investigations_base
+    crime_matter_type:
+    duty_solicitor:
+    no_of_police_station:
+    no_of_suspects:
+    outcome_code:
+    police_station:
+    schedule_ref:
+    travel_costs:
+    travel_waiting_costs:
+    youth_court:
+
+  police_station_attendance: &police_station_attendance
+    <<: *criminal_investigations_base
+    crime_matter_type:
+    dscc_number:
+    duty_solicitor:
+    excess_travel_costs:
+    no_of_police_station:
+    no_of_suspects:
+    outcome_code:
+    police_station:
+    schedule_ref:
+    scheme_id:
+    travel_costs:
+    travel_waiting_costs:
+    youth_court:
+
+  pre-charge_bail: &pre-charge_bail
+    <<: *warrant_of_further_detention
+
+appeals_and_reviews_base: &appeals_and_reviews_base
+  client_forename:
+  client_surname:
+  disability:
+  disbursements_amount:
+  disbursements_vat:
+  ethnicity:
+  gender:
+  profit_cost:
+  schedule_ref:
+  travel_costs:
+  travel_waiting_costs:
+  ufn:
+  vat_indicator:
+  work_concluded_date:
+  youth_court:
+
+prison_law_base: &prison_law_base
+  client_forename:
+  client_surname:
+  crime_matter_type:
+  disability:
+  disbursements_amount:
+  disbursements_vat:
+  ethnicity:
+  gender:
+  outcome_code:
+  pa_number:
+  police_station:
+  profit_cost:
+  schedule_ref:
+  travel_costs:
+  travel_waiting_costs:
+  ufn:
+  vat_indicator:
+  work_concluded_date:
+
+associated_civil_work_base: &associated_civil_work_base
+  client_forename:
+  client_surname:
+  disability:
+  disbursements_amount:
+  disbursements_vat:
+  ethnicity:
+  gender:
+  profit_cost:
+  schedule_ref:
+  travel_costs:
+  travel_waiting_costs:
+  ufn:
+  vat_indicator:
+  work_concluded_date:
+  youth_court:
+
+crime_lower:
+  criminal_investigations:
+    #INV<x> codes: 7 fee schemes
+    INVA:
+      <<: *criminal_investigations_base
+      crime_matter_type:
+      outcome_code:
+      schedule_ref:
+      travel_costs:
+      travel_waiting_costs:
+      youth_court:
+
+    INVB:
+      <<: *criminal_investigations_base
+      crime_matter_type:
+      dscc_number:
+      duty_solicitor:
+      outcome_code:
+      police_station:
+      schedule_ref:
+      travel_costs:
+      travel_waiting_costs:
+      youth_court:
+
+    INVC:
+      <<: *police_station_attendance
+
+    INVD:
+      <<: *police_station_attendance
+
+    INVE:
+      <<: *warrant_of_further_detention
+
+    INVF:
+      <<: *warrant_of_further_detention
+
+    INVG:
+      disbursements_amount:
+      disbursements_vat:
+      profit_cost:
+      schedule_ref:
+      vat_indicator:
+
+    INVH:
+      <<: *post_charge_attendance
+
+    INVI:
+      <<: *post_charge_attendance
+
+    INVJ:
+
+    INVK:
+      <<: *pre-charge_bail
+    INVL:
+      <<: *pre-charge_bail
+
+    INVM:
+
+  #PRO<x> codes
+  criminal_proceedings:
+    PROC:
+
+    PROD:
+
+    PROE:
+
+    PROF:
+
+    PROG:
+
+    PROH:
+
+    PROI:
+
+    PROJ:
+
+    PROK:
+
+    PROL:
+
+    PROM:
+
+    PROP:
+
+    PROT:
+
+    PROU:
+
+    PROV:
+
+    PROW:
+
+  #APPA, APPB, APPC
+  appeals_and_reviews:
+    APPA:
+      <<: *appeals_and_reviews_base
+    APPB:
+      <<: *appeals_and_reviews_base
+    APPC:
+      <<: *appeals_and_reviews_base
+
+  #PRI<x> codes
+  prison_law:
+    PRIA:
+      <<: *prison_law_base
+    PRIB:
+      <<: *prison_law_base
+    PRIC:
+      <<: *prison_law_base
+    PRID:
+      <<: *prison_law_base
+    PRIE:
+      <<: *prison_law_base
+
+  #ASMS, ASPL, ASAS
+  associated_civil_work:
+    ASMS:
+      <<: *associated_civil_work_base
+    ASPL:
+      <<: *associated_civil_work_base
+    ASAS:
+      <<: *associated_civil_work_base

--- a/features/support/am/defaults/am_legal_help_defaults.yml
+++ b/features/support/am/defaults/am_legal_help_defaults.yml
@@ -1,0 +1,173 @@
+#Note: currently missing tolerance_indicator field (which we want to remove) and postal_appl_accp
+base: &base_defaults
+  access_point: AP00000
+  case_ref_number: TestCaseRef
+  client_date_of_birth: 14/09/1962
+  client_forename: Test
+  client_post_code: SW1H 9EA
+  client_surname: Person
+  disability: UKN
+  disbursements_amount: 0
+  disbursements_vat: 0
+  ethnicity: 99
+  gender: F
+  ucn: 14091962/T/PERS
+  work_concluded_date:
+
+#additional base fields added to 'completed matter' claims
+base_cm: &base_defaults_cm
+  <<: *base_defaults
+  profit_cost: 500
+  waiting_time: 0
+  counsel_cost: 0
+  vat_indicator: N
+  travel_waiting_costs: 0
+  advice_time: 0
+  travel_time: 0
+  exemption_criteria_satisfied:
+
+#immigration base fields added to all immigration claim types
+immigration_base: &immigration_base_defaults
+  ho_ucn: A9999999
+  ho_interview: 0
+
+#immigration 'completed matter' claims inc base_cm and immigration_base plus others
+immigration_base_cm: &immigration_base_cm_defaults
+  <<: *base_defaults_cm
+  <<: *immigration_base_defaults
+  legacy_case: N
+  travel_costs: 0
+  jr_form_filling:
+  substantive_hearing: N
+  cmrh_oral: 0
+  ait_hearing_centre: 16
+  cmrh_telephone: 0
+  adjourned_hearing_fee: 0
+  claim_type: Completed Matter Claim
+  access_point: AP00137
+  procurement_area: PA00136
+  outcome_code: IX
+  postal_appl_accp: Y
+
+legal_help:
+  completed_matter:
+    welfare_benefits:
+      <<: *base_defaults
+      procurement_area: PA00125
+      stage_reached: DA
+      outcome_code: DA
+
+    education:
+      <<: *base_defaults
+      procurement_area: PA00180
+      stage_reached: EA
+      outcome_code: EA
+
+    family:
+      <<: *base_defaults
+      #family specific fields
+      london_nonlondon_rate:
+      value_of_costs:
+      local_authority_number:
+      client_type:
+      case_stage_level:
+
+    discrimination:
+      <<: *base_defaults
+      procurement_area:
+      stage_reached:
+      outcome_code:
+
+    claims_against_public_authorities:
+      <<: *base_defaults
+      procurement_area:
+      stage_reached:
+      outcome_code:
+
+    community_care:
+      <<: *base_defaults
+      procurement_area:
+      stage_reached:
+      outcome_code:
+
+    consumer_general_contract:
+      <<: *base_defaults
+      procurement_area:
+      stage_reached:
+      outcome_code:
+
+    employment:
+      <<: *base_defaults
+      procurement_area:
+      stage_reached:
+      outcome_code:
+
+    clinical_negligence:
+      <<: *base_defaults
+      procurement_area:
+      stage_reached:
+      outcome_code:
+
+    residual_miscellaneous:
+      <<: *base_defaults
+      procurement_area:
+      stage_reached:
+      outcome_code:
+
+    personal_injury:
+      <<: *base_defaults
+      procurement_area:
+      stage_reached:
+      outcome_code:
+
+    public_law:
+      <<: *base_defaults
+      procurement_area:
+      stage_reached:
+      outcome_code:
+
+    housing:
+      <<: *base_defaults
+      #housing specific fields
+      eligible_client_indicator:
+      court_location_hpcds:
+
+    debt:
+      <<: *base_defaults
+      #debt specific fields
+      cla_ref_number:
+      cla_exemption:
+
+    mental_health:
+      <<: *base_defaults
+      procurement_area:
+      stage_reached:
+      outcome_code:
+
+    immigration:
+      <<: *immigration_base_cm_defaults
+      stage_reached:
+
+    immigration_and_asylum:
+      <<: *immigration_base_cm_defaults
+      stage_reached:
+
+  stage_claim:
+      immigration:
+        <<: *base_defaults
+        claim_type:  Stage Claim
+
+      immigration_and_asylum:
+        <<: *base_defaults
+
+  disbursement_claim:
+      immigration:
+        <<: *base_defaults
+        claim_type:  Disbursements Claim
+
+      immigration_and_asylum:
+        <<: *base_defaults
+
+      mental_health:
+        <<: *base_defaults
+        procurement_area: PA00158

--- a/features/support/am/defaults/am_mediation_defaults.yml
+++ b/features/support/am/defaults/am_mediation_defaults.yml
@@ -1,0 +1,43 @@
+base_mediation: &base_mediation
+  case_id:
+  case_ref_number:
+  case_start_date:
+  client2_date_of_birth:
+  client2_disability:
+  client2_ethnicity:
+  client2_forename:
+  client2_gender:
+  client2_legally_aided:
+  client2_post_code:
+  client2_postal_appl_accp:
+  client2_surname:
+  client2_ucn:
+  client_date_of_birth:
+  client_forename:
+  client_legally_aided:
+  client_post_code:
+  client_surname:
+  disability:
+  disbursements_amount:
+  disbursements_vat:
+  ethnicity:
+  gender:
+  outreach:
+  postal_appl_accp:
+  referral:
+  schedule_ref:
+  ucn:
+  unique_case_id:
+  vat_indicator:
+
+mediation:
+  #MT1 code
+  MEDI:
+    <<: *base_mediation
+
+  ASSM:
+    <<: *base_mediation
+    med_concluded_date:
+    mediation_time:
+    number_of_mediation_sessions:
+    outcome_code:

--- a/features/support/am/fields/am_crime_lower.yml
+++ b/features/support/am/fields/am_crime_lower.yml
@@ -1,0 +1,234 @@
+criminal_investigations:
+  criminal_investigations_base: &criminal_investigations_base
+    client_forename:
+    client_surname:
+    disability:
+    disbursements_amount:
+    disbursements_vat:
+    ethnicity:
+    gender:
+    profit_cost:
+    ufn:
+    vat_indicator:
+    work_concluded_date:
+
+  post_charge_attendance: &post_charge_attendance
+    <<: *criminal_investigations_base
+    dscc_number:
+    duty_solicitor:
+    no_of_police_station:
+    no_of_suspects:
+    police_station:
+    schedule_ref:
+    travel_costs:
+    travel_waiting_costs:
+    youth_court:
+
+  warrant_of_further_detention: &warrant_of_further_detention
+    <<: *criminal_investigations_base
+    crime_matter_type:
+    duty_solicitor:
+    no_of_police_station:
+    no_of_suspects:
+    outcome_code:
+    police_station:
+    schedule_ref:
+    travel_costs:
+    travel_waiting_costs:
+    youth_court:
+
+  police_station_attendance: &police_station_attendance
+    <<: *criminal_investigations_base
+    crime_matter_type:
+    dscc_number:
+    duty_solicitor:
+    excess_travel_costs:
+    no_of_police_station:
+    no_of_suspects:
+    outcome_code:
+    police_station:
+    schedule_ref:
+    scheme_id:
+    travel_costs:
+    travel_waiting_costs:
+    youth_court:
+
+  pre-charge_bail: &pre-charge_bail
+    <<: *warrant_of_further_detention
+
+appeals_and_reviews_base: &appeals_and_reviews_base
+  client_forename:
+  client_surname:
+  disability:
+  disbursements_amount:
+  disbursements_vat:
+  ethnicity:
+  gender:
+  profit_cost:
+  schedule_ref:
+  travel_costs:
+  travel_waiting_costs:
+  ufn:
+  vat_indicator:
+  work_concluded_date:
+  youth_court:
+
+prison_law_base: &prison_law_base
+  client_forename:
+  client_surname:
+  crime_matter_type:
+  disability:
+  disbursements_amount:
+  disbursements_vat:
+  ethnicity:
+  gender:
+  outcome_code:
+  pa_number:
+  police_station:
+  profit_cost:
+  schedule_ref:
+  travel_costs:
+  travel_waiting_costs:
+  ufn:
+  vat_indicator:
+  work_concluded_date:
+
+associated_civil_work_base: &associated_civil_work_base
+  client_forename:
+  client_surname:
+  disability:
+  disbursements_amount:
+  disbursements_vat:
+  ethnicity:
+  gender:
+  profit_cost:
+  schedule_ref:
+  travel_costs:
+  travel_waiting_costs:
+  ufn:
+  vat_indicator:
+  work_concluded_date:
+  youth_court:
+
+crime_lower:
+  criminal_investigations:
+    #INV<x> codes: 7 fee schemes
+    INVA:
+      <<: *criminal_investigations_base
+      crime_matter_type:
+      outcome_code:
+      schedule_ref:
+      travel_costs:
+      travel_waiting_costs:
+      youth_court:
+
+    INVB:
+      <<: *criminal_investigations_base
+      crime_matter_type:
+      dscc_number:
+      duty_solicitor:
+      outcome_code:
+      police_station:
+      schedule_ref:
+      travel_costs:
+      travel_waiting_costs:
+      youth_court:
+
+    INVC:
+      <<: *police_station_attendance
+
+    INVD:
+      <<: *police_station_attendance
+
+    INVE:
+      <<: *warrant_of_further_detention
+
+    INVF:
+      <<: *warrant_of_further_detention
+
+    INVG:
+      disbursements_amount:
+      disbursements_vat:
+      profit_cost:
+      schedule_ref:
+      vat_indicator:
+
+    INVH:
+      <<: *post_charge_attendance
+
+    INVI:
+      <<: *post_charge_attendance
+
+    INVJ:
+
+    INVK:
+      <<: *pre-charge_bail
+    INVL:
+      <<: *pre-charge_bail
+
+    INVM:
+
+  #PRO<x> codes
+  criminal_proceedings:
+    PROC:
+
+    PROD:
+
+    PROE:
+
+    PROF:
+
+    PROG:
+
+    PROH:
+
+    PROI:
+
+    PROJ:
+
+    PROK:
+
+    PROL:
+
+    PROM:
+
+    PROP:
+
+    PROT:
+
+    PROU:
+
+    PROV:
+
+    PROW:
+
+  #APPA, APPB, APPC
+  appeals_and_reviews:
+    APPA:
+      <<: *appeals_and_reviews_base
+    APPB:
+      <<: *appeals_and_reviews_base
+    APPC:
+      <<: *appeals_and_reviews_base
+
+  #PRI<x> codes
+  prison_law:
+    PRIA:
+      <<: *prison_law_base
+    PRIB:
+      <<: *prison_law_base
+    PRIC:
+      <<: *prison_law_base
+    PRID:
+      <<: *prison_law_base
+    PRIE:
+      <<: *prison_law_base
+
+  #ASMS, ASPL, ASAS
+  associated_civil_work:
+    ASMS:
+      <<: *associated_civil_work_base
+    ASPL:
+      <<: *associated_civil_work_base
+    ASAS:
+      <<: *associated_civil_work_base

--- a/features/support/am/fields/am_legal_help.yml
+++ b/features/support/am/fields/am_legal_help.yml
@@ -1,0 +1,171 @@
+#Note: currently missing tolerance_indicator field (which we want to remove) and postal_appl_accp
+base: &base
+  work_concluded_date:
+  ucn:
+  transfer_date:
+  case_start_date:
+  gender:
+  procurement_area:
+  stage_reached:
+  disability:
+  case_id:
+  excl_case_funding_ref:
+  outcome_code:
+  disbursements_amount:
+  client_post_code:
+  access_point:
+  client_forename:
+  ethnicity:
+  schedule_ref:
+  disbursements_vat:
+  client_date_of_birth:
+  client_surname:
+  case_ref_number:
+
+#additional base fields added to 'completed matter' claims
+base_cm: &base_cm
+  <<: *base
+  profit_cost:
+  waiting_time:
+  counsel_cost:
+  vat_indicator:
+  travel_waiting_costs:
+  advice_time:
+  travel_time:
+  exemption_criteria_satisfied:
+
+#additional base fields added to 'stage claim' claims
+base_sc: &base_sc
+  <<: *base_cm
+
+#'disbursement claim' claims just use base fields
+base_dc: &base_dc
+  <<: *base
+
+#immigration base fields added to all immigration claim types
+immigration_base: &immigration_base
+  ho_ucn:
+  ho_interview:
+  prior_authority_ref:
+
+#immigration 'completed matter' claims inc base_cm and immigration_base plus others
+immigration_base_cm: &immigration_base_cm
+  <<: *base_cm
+  <<: *immigration_base
+  legacy_case:
+  travel_costs:
+  jr_form_filling:
+  substantive_hearing:
+  cmrh_oral:
+  ait_hearing_centre:
+  cmrh_telephone:
+  adjourned_hearing_fee:
+  claim_type:
+
+#immigration 'stage claim' claims a mirror of immigration_base_cm
+immigration_base_sc: &immigration_base_sc
+  <<: *immigration_base_cm
+
+#immigration 'disbursement claim' claims only use base_dc plus immigrationb_base
+immigration_base_dc: &immigration_base_dc
+  <<: *base_dc
+  <<: *immigration_base
+
+#mental health 'completed matter' claims use base_cm fields plus extra ones
+mental_health_base_cm: &mental_health_base_cm
+  <<: *base_cm
+  case_stage_level:
+  desi_acc_rep:
+  mht_ref_number:
+  meetings_attended:
+  additional_travel_payment:
+  medical_reports_claimed:
+
+#mental health 'disbursement claims' claims use base_dc
+mental_health_base_dc: &mental_health_base_dc
+  <<: *base_dc
+
+legal_help:
+  completed_matter:
+    welfare_benefits:
+      <<: *base_cm
+      #welfare benefits specific fields
+      type_of_advice: REMOTE
+      delivery_location:
+
+    education:
+      *base_cm
+
+    family:
+      <<: *base_cm
+      #family specific fields
+      london_nonlondon_rate:
+      value_of_costs:
+      local_authority_number:
+      client_type:
+      case_stage_level:
+
+    discrimination:
+      *base_cm
+
+    claims_against_public_authorities:
+      *base_cm
+
+    community_care:
+      *base_cm
+
+    consumer_general_contract:
+      *base_cm
+
+    employment:
+      *base_cm
+
+    clinical_negligence:
+      *base_cm
+
+    residual_miscellaneous:
+      *base_cm
+
+    personal_injury:
+      *base_cm
+
+    public_law:
+      *base_cm
+
+    housing:
+      <<: *base_cm
+      #housing specific fields
+      eligible_client_indicator:
+      court_location_hpcds:
+
+    debt:
+      <<: *base_cm
+      #debt specific fields
+      cla_ref_number:
+      cla_exemption:
+
+    mental_health:
+      <<: *mental_health_base_cm
+
+    immigration:
+      <<: *immigration_base_cm
+
+    immigration_and_asylum:
+      <<: *immigration_base_cm
+
+  stage_claim:
+      immigration:
+        <<: *immigration_base_sc
+
+      immigration_and_asylum:
+        <<: *immigration_base_sc
+
+  disbursement_claim:
+      immigration:
+        <<: *immigration_base_dc
+
+      immigration_and_asylum:
+        <<: *immigration_base_dc
+
+      mental_health:
+        <<: *mental_health_base_dc

--- a/features/support/am/fields/am_mediation.yml
+++ b/features/support/am/fields/am_mediation.yml
@@ -1,0 +1,43 @@
+base_mediation: &base_mediation
+  case_id:
+  case_ref_number:
+  case_start_date:
+  client2_date_of_birth:
+  client2_disability:
+  client2_ethnicity:
+  client2_forename:
+  client2_gender:
+  client2_legally_aided:
+  client2_post_code:
+  client2_postal_appl_accp:
+  client2_surname:
+  client2_ucn:
+  client_date_of_birth:
+  client_forename:
+  client_legally_aided:
+  client_post_code:
+  client_surname:
+  disability:
+  disbursements_amount:
+  disbursements_vat:
+  ethnicity:
+  gender:
+  outreach:
+  postal_appl_accp:
+  referral:
+  schedule_ref:
+  ucn:
+  unique_case_id:
+  vat_indicator:
+
+mediation:
+  #MT1 code
+  MEDI:
+    <<: *base_mediation
+
+  ASSM:
+    <<: *base_mediation
+    med_concluded_date:
+    mediation_time:
+    number_of_mediation_sessions:
+    outcome_code:

--- a/features/support/helpers/screen_field_builder.rb
+++ b/features/support/helpers/screen_field_builder.rb
@@ -1,0 +1,64 @@
+require 'yaml'
+require 'date'
+
+module Helpers
+  module ScreenFieldBuilder
+
+    DEFAULTS_DIR = 'features/support/am/defaults/'
+    FIELDS_DIR = 'features/support/am/fields/'
+
+    def self.get_fields(*args)
+      area_of_law = args[0][0]
+      if area_of_law == 'crime_lower'
+        am_fields = YAML.load_file(File.expand_path (FIELDS_DIR + 'am_crime_lower.yml'))
+        am_defaults = YAML.load_file(File.expand_path(DEFAULTS_DIR + 'am_crime_lower_defaults.yml'))
+        category = args[0][1]
+        stage_reached_code = args[0][2]
+
+        am_data = am_fields[area_of_law][category][stage_reached_code]
+        am_data_defaults = am_defaults[area_of_law][category][stage_reached_code]
+
+        am_data.update(am_data_defaults)
+
+      elsif area_of_law == 'legal_help'
+        category_of_law = args[0][1]
+        case args[0].length
+        when 1
+          raise ArgumentError, "For Legal Help at least 2 arguments required (area_of_law, category_of_law)"
+        when 2
+          # claim_type was not given
+          claim_type = 'completed_matter'
+        when 3
+          claim_type = args[0][2]
+        else
+          raise ArgumentError, "For Legal Help a maximum of 3 arguments is required (area_of_law, category_of_law, claim_type)"
+        end
+
+        am_fields = YAML.load_file(File.expand_path (FIELDS_DIR + 'am_legal_help.yml'))
+        am_defaults = YAML.load_file(File.expand_path(DEFAULTS_DIR + 'am_legal_help_defaults.yml'))
+
+        am_data = am_fields[area_of_law][claim_type][category_of_law]
+        am_data_defaults = am_defaults[area_of_law][claim_type][category_of_law]
+
+        am_data.update(am_data_defaults)
+        am_data.update({'work_concluded_date'=>Time.now.strftime("%d/%m/%Y")})
+      elsif area_of_law == 'mediation'
+        am_fields = YAML.load_file(File.expand_path(DEFAULTS_DIR + 'am_mediation.yml'))
+        am_defaults = YAML.load_file(File.expand_path(DEFAULTS_DIR + 'am_mediation_defaults.yml'))
+        matter_type_code = args[0][1]
+
+        am_data = am_fields[area_of_law][matter_type_code]
+        am_data_defaults = am_defaults[area_of_law][matter_type_code]
+
+        am_data.update(am_data_defaults)
+      else
+        raise TypeError, "Area Of Law '#{area_of_law}' not recognised."
+      end
+      return am_data
+    rescue NoMethodError => e
+      puts "Unable to retrieve the following keys from the yaml file using #{args[0]}"
+      puts e.message
+      puts e.backtrace
+    end
+  end
+end

--- a/features/support/ui/add_outcome_page.rb
+++ b/features/support/ui/add_outcome_page.rb
@@ -108,8 +108,10 @@ JS
       claim_type.select(values[:claim_type])
     end
     wait_until_schedule_reference_visible(wait: 10)
-    schedule_reference.set(values[:schedule_reference])
-    case_reference_number.set(values[:case_reference_number])
+    schedule_reference.set(values[:schedule_ref])
+
+    case_reference_number.set(values[:case_ref_number])
+
     case_start_date.set(values[:case_start_date])
     case_id.set(values[:case_id])
     set_value_sync(procurement_area, values[:procurement_area])
@@ -118,38 +120,55 @@ JS
     client_surname.set(values[:client_surname])
     client_date_of_birth.set(values[:client_date_of_birth])
     ucn.set(values[:ucn])
-    postal_application_accepted.select(values[:postal_application_accepted])
+
+    postal_application_accepted.select(values[:postal_appl_accp])
+
     gender.select(values[:gender])
     ethnicity.select(values[:ethnicity])
     disability.select(values[:disability])
-    client_postcode.set(values[:client_postcode])
-    case_concluded_date.set(values[:case_concluded_date])
+    client_postcode.set(values[:client_post_code])
+
+    case_concluded_date.set(values[:work_concluded_date])
+
     case_concluded_date.send_keys(:tab)
     advice_time.set(values[:advice_time])
     travel_time.set(values[:travel_time])
     waiting_time.set(values[:waiting_time])
-    profit_costs_excluding_vat.set(values[:profit_costs_excluding_vat])
-    disbursements_excluding_vat.set(values[:disbursements_excluding_vat])
-    counsel_costs_excluding_vat.set(values[:counsel_costs_excluding_vat])
-    disbursements_vat_amount.set(values[:disbursements_vat_amount])
-    profit_and_counsel_vat_indicator.select(values[:profit_and_counsel_vat_indicator])
+
+    profit_costs_excluding_vat.set(values[:profit_cost])
+
+    disbursements_excluding_vat.set(values[:disbursements_amount])
+
+    counsel_costs_excluding_vat.set(values[:counsel_cost])
+
+    disbursements_vat_amount.set(values[:disbursements_vat])
+
+    profit_and_counsel_vat_indicator.select(values[:vat_indicator])
+
     london_rate.select(values[:london_rate]) if values[:london_rate]
     tolerance_indicator.select(values[:tolerance_indicator]) if values[:tolerance_indicator]
-    travel_and_waiting_costs_excluding_vat.set(values[:travel_and_waiting_costs_excluding_vat])
+
+    travel_and_waiting_costs_excluding_vat.set(values[:travel_waiting_costs])
+
     value_of_costs_damages_awarded.set(values[:value_of_costs_damages_awarded]) if values[:value_of_costs_damages_awarded]
     stage_reached.select(values[:stage_reached]) if values[:stage_reached]
     local_authority_number.set(values[:local_authority_number]) if values[:local_authority_number]
     client_type.select(values[:client_type]) if values[:client_type]
-    outcome_for_client.select(values[:outcome_for_client])
+
+    outcome_for_client.select(values[:outcome_code])
     case_stage_level.select(values[:case_stage_level]) if values[:case_stage_level]
 
-    home_office_ucn.set(values[:home_office_ucn]) if values[:home_office_ucn]
+    home_office_ucn.set(values[:home_office_ucn]) if values[:ho_ucn]
+
     legacy_case.select(values[:legacy_case]) if values[:legacy_case]
     ho_interview.select(values[:ho_interview]) if values[:ho_interview]
     ait_hearing_centre.select(values[:ait_hearing_centre]) if values[:ait_hearing_centre]
     adjourned_hearing_fee.set(values[:adjourned_hearing_fee]) if values[:adjourned_hearing_fee]
-    detention_travel_and_waiting_costs_excluding_vat.set(values[:detention_travel_and_waiting_costs_excluding_vat]) if values[:detention_travel_and_waiting_costs_excluding_vat]
-    jr_form_filling_costs_excluding_vat.set(values[:jr_form_filling_costs_excluding_vat]) if values[:jr_form_filling_costs_excluding_vat]
+
+    detention_travel_and_waiting_costs_excluding_vat.set(values[:travel_costs]) if values[:travel_costs]
+
+    jr_form_filling_costs_excluding_vat.set(values[:jr_form_filling]) if values[:jr_form_filling]
+
     cmrh_oral.select(values[:cmrh_oral]) if values[:cmrh_oral]
     cmrh_telephone.select(values[:cmrh_telephone]) if values[:cmrh_telephone]
     substantive_hearing.select(values[:substantive_hearing]) if values[:substantive_hearing]

--- a/features/validations/legal_help/immigration_and_asylum/ho_ucn_validation_manual.feature
+++ b/features/validations/legal_help/immigration_and_asylum/ho_ucn_validation_manual.feature
@@ -1,0 +1,23 @@
+Feature: Validation of Home Office UCN for Immigration and Asylum claims
+
+@delete_outcome_after @manual_submission @valid @ho_ucn
+Scenario: Add valid Immigration and Asylum claims using new HO_UCN format
+    Given user is on their submission details page
+    When user adds outcomes for Immigration with fields like this:
+    | case_id | matter_type | case_start_date | home_office_ucn   |
+    | 001     | IMCC:IDOM   | 01/11/19        | 12345678 |
+    | 002     | IMCC:IDOM   | 01/11/19        | ABCDEFGH |
+
+    Then the outcome saves successfully
+
+@delete_outcome_after @manual_submission @invalid @ho_ucn
+Scenario: Add valid Immigration and Asylum claims using new HO_UCN format
+    Given user is on their submission details page
+    When user adds outcomes for Immigration with fields like this:
+    | case_id | matter_type | case_start_date | home_office_ucn   |
+    | 001     | IMCC:IDOM   | 01/11/19        |                   |
+
+    Then the outcome does not save and this popup error appears:
+    """
+    A value must be entered for "Home Office UCN"
+    """

--- a/features/validations/legal_help/immigration_and_asylum/ho_ucn_validations.feature
+++ b/features/validations/legal_help/immigration_and_asylum/ho_ucn_validations.feature
@@ -1,0 +1,29 @@
+Feature: Immigration Bulk load validations
+
+  Background:
+    Given a test firm user is logged in CWA
+    And user prepares to submit outcomes for test provider "LEGAL HELP.IMMOT#4"
+
+  Scenario: Bulkload Civil Immigration outcomes with HO_UCN
+    Given the following Matter Types are chosen:
+      | IMCC:IDOM |
+    And the following outcomes are bulkloaded:
+      | # | CASE_START_DATE | HO_UCN |
+      | 1 | 01/04/2013      |        |
+      | 2 | 01/04/2013      | 1AAAAAAA1AAAAAAA1AAAAAAA |
+    Then the following results are expected:
+      | # | ERROR_CODE_OR_MESSAGE          |
+      | 1 | HO_UCN is missing              |
+      | 2 | Value :1AAAAAAA1AAAAAAA1AAAAAAA is not valid for : HO_UCN |
+
+  Scenario: Bulkload Civil Immigration outcomes with HO_UCN
+    Given the following Matter Types are chosen:
+      | IMCC:IDOM |
+    And the following outcomes are bulkloaded:
+      | # | CASE_START_DATE | HO_UCN   |
+      | 1 | 01/04/2013      | 1AAAAAAA |
+      | 2 | 01/04/2013      | 1AAAAAAA1AAAAAAA |
+    Then the following results are expected:
+      | # | ERROR_CODE_OR_MESSAGE |
+      | 1 | <none>                |
+      | 2 | <none>                |


### PR DESCRIPTION
## What does this pull request do?

Created feature tests to support the validation of ho_ucn.  Tests now detect and process popup messages where errors have occurred in manual submission (like the absence of a ho_ucn code).

Fields which appear on submissions screens have been extracted from CWA and placed in yaml config files. 

Defaults have been embedded into separate yaml config files as well.

Yaml files covering all areas of law (AOL) have been created to support the use of these files across all AOLs moving forward.  Coverage in the legal help ones are mostly there.  Mediation and Crime Lower still need a bit of work filling out some of the lists.

A new helper file has been created to grab data from the files.  This is called from the implementation steps.

Tidy up to delete a redundant (and empty?) claim_type feature.  

Note: It is possible some of the changes break feature tests.  But this will have to be addressed in a later ticket (unless the breaks are small), and the breakage is worth it!

## Why make these changes?

No implementation existed to trap and process popups.

Yaml files are to support a move away from using this information in the cwa_env.yml config file which is currently getting unwieldy and does too much atm (i.e. test provider data, fields, defaults vals, error messages).

## Checklist

- [x] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-1366
