### PR TITLE
TA-1871 mod case start date year to 4 digits in housing manual feature

### DIFF
--- a/features/validations/legal_help/housing/housing_validation_manual.feature
+++ b/features/validations/legal_help/housing/housing_validation_manual.feature
@@ -7,6 +7,6 @@ Feature: Validation for Housing claims
     Scenario Outline: Add valid Housing claims using Disability Code
         When user adds outcomes for "Legal Help" "Housing" with fields like this:
         | case_id | matter_type | case_start_date | procurement_area | access_point | disability |
-        | 001     | HHOM:HPRI   | 01/11/19        | PA00119          | AP00000      | COG        |
+        | 001     | HHOM:HPRI   | 01/11/2019      | PA00119          | AP00000      | COG        |
 
         Then the outcome saves successfully


### PR DESCRIPTION
## What does this pull request do?

Please describe what you did.
Modified the housing manual feature to ensure the case start date is passed with a 4 digit year rather than 2 digits.

## Why make these changes?

Please describe why the changes were needed.
Passing as a 2-digit year causes problems when that gets translated to 4-digits in the UI with the result that the test is failing.

## Checklist

- [x] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-1871
