### PR TITLE
Add new step definitions with single error expectation

### DIFF
--- a/features/step_definitions/bulk_load_steps.rb
+++ b/features/step_definitions/bulk_load_steps.rb
@@ -66,6 +66,35 @@ When(/^the following outcomes are bulkloaded(\sand\sconfirmed)?:$/) do |confirm,
   step('user confirms the submission') if confirm
 end
 
+Then('the following error message is expected for each:') do |expected_message|
+  @bulk_load_results_page = BulkLoadResultsPage.new
+  @bulk_load_results_page.wait_until_summary_visible(wait: 30)
+
+  actual_results = @bulk_load_results_page.errors.reduce({}) do |memo, error|
+    case_id = error.client_surname.text.split.last
+    if case_id
+      error_message = error.description.text
+      all_errors = memo.fetch(case_id, []) << error_message
+      memo.merge(case_id => all_errors)
+    else
+      memo
+    end
+  end
+
+  @matter_types.flat_map.each.with_index(1) do |matter_type, i|
+    STDOUT.puts("Testing #{matter_type}")
+
+    case_id = "%03d" % i
+    actual_errors = actual_results.fetch(case_id, [])
+
+    if expected_message == '<none>'
+      expect(actual_errors).to eq([])
+    else
+      expect(actual_errors).to contain_exactly(expected_message)
+    end
+  end
+end
+
 Then('the following results are expected:') do |table|
   @bulk_load_results_page = BulkLoadResultsPage.new
   @bulk_load_results_page.wait_until_summary_visible(wait: 30)


### PR DESCRIPTION
## What does this pull request do?

Introduces two steps that can be used when expecting a single error (or none!) from all the bulkloaded outcomes in a scenario.

## Why make these changes?

The existing step definition for a similar scenario would require a table with the same error repeated N times, where N is the number of matter types currently tested for a particular validation.

Example usage:

```
  Background:
    Given a test firm user is logged in CWA
    And user prepares to submit outcomes for test provider "CRIME LOWER#8"
    Given the following Matter Types are chosen:
    | INVM |
    | INVJ |
...
  Scenario: Bulkoad Crime Lower outcomes with SCHEME_ID
    When the following outcomes are bulkloaded:
    | # | UFN        | SCHEME_ID |
    | 1 | 181020/001 | <blank>   |
    | 2 | 181020/002 | <blank>   |
    | 3 | 181020/003 | <blank>   |
    Then the following error message is expected for each:
    """
    SCHEME_ID is missing
    """
...
    Then no error message is expected for each
```

## Checklist

- [ ] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-XXX
