### PR TITLE
TAP-1556 | add test for child migrant asylum/imm

### DIFF
--- a/features/pricing/legal_help/asylum/child_migrant.feature
+++ b/features/pricing/legal_help/asylum/child_migrant.feature
@@ -1,0 +1,20 @@
+Feature: Pricing: IAXC Assylum  Child Migrant
+
+ Background:
+    Given a test firm user is logged in CWA
+    And user prepares to submit outcomes for test provider "LEGAL HELP.IMMOT#4"
+  
+   Scenario: For Completed Matter claim, using Child Migrant ECS for Assylum
+   Given the following Matter Types are chosen:
+    | IAXC:IRAR |
+   When the following outcomes are bulkloaded:
+      | # | UFN          | CLAIM_TYPE | CASE_START_DATE | WORK_CONCLUDED_DATE |  PROFIT_COST | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT | COUNSEL_COST  | EXEMPTION_CRITERIA_SATISFIED  | VAT_INDICATOR |
+      | 1 | 010120/001   | CM         | 01/01/2020      | 31/03/2020          |  3000.00     | 3000.00              | 600.00            | 3000.00       |             CM001             |       Y       |
+      | 2 | 010120/002   | CM         | 01/01/2020      | 31/03/2020          |  3000.00     | 2000.00              | 400.00            | 1000.00       |             CM001             |       N       |
+   
+   When user confirms the submission
+   And user is on the pricing outcome details page
+   Then user should see the following outcomes:
+      | # | UFN        | Value         |
+      | 1 | 010120/001 | £ 10,800.00   |
+      | 2 | 010120/002 | £ 6,400.00    |

--- a/features/pricing/legal_help/immigration/IMXC.feature
+++ b/features/pricing/legal_help/immigration/IMXC.feature
@@ -51,19 +51,20 @@ Feature: Pricing: IMXC: Immigration - CLR Work Not Subject to the Standard Fee S
   Scenario: Claims priced with: Hourly Rates (Separated Migrant Child) (1)
     When the user adds outcomes with:
       """
-      exemption criteria separated migrant child below the max price cap
+      exemption criteria separated migrant child above the max price cap
       """
     Then the outcomes are priced at:
       """
       hourly rates
       """
 
-  Scenario: Claims priced with: Hourly Rates (Separated Migrant Child) (2)
+  Scenario: Claims priced with: Hourly Rates (Separated Migrant Child) (1)
     When the user adds outcomes with:
       """
-      exemption criteria separated migrant child above the max price cap
+      exemption criteria separated migrant child below the max price cap
       """
     Then the outcomes are priced at:
       """
-      max price cap
+      hourly rates
       """
+  

--- a/features/pricing/legal_help/immigration/IMXL.feature
+++ b/features/pricing/legal_help/immigration/IMXL.feature
@@ -51,19 +51,19 @@ Feature: Pricing: IMXL: Immigration - LH Work Not Subject to the Standard Fee Sc
   Scenario: Claims priced with: Hourly Rates (Separated Migrant Child) (1)
     When the user adds outcomes with:
       """
-      exemption criteria separated migrant child below the max price cap
+      exemption criteria separated migrant child above the max price cap
       """
     Then the outcomes are priced at:
       """
       hourly rates
       """
 
-  Scenario: Claims priced with: Hourly Rates (Separated Migrant Child) (2)
+  Scenario: Claims priced with: Hourly Rates (Separated Migrant Child) (1)
     When the user adds outcomes with:
       """
-      exemption criteria separated migrant child above the max price cap
+      exemption criteria separated migrant child below the max price cap
       """
     Then the outcomes are priced at:
       """
-      max price cap
+      hourly rates
       """

--- a/features/pricing/legal_help/immigration/child_migrant.feature
+++ b/features/pricing/legal_help/immigration/child_migrant.feature
@@ -1,0 +1,19 @@
+Feature: Pricing: IMXL: Immigration - IAXC Assylum  Child Migrant
+
+ Background:
+    Given a test firm user is logged in CWA
+    And user prepares to submit outcomes for test provider "LEGAL HELP.IMMOT#4"
+
+   Scenario: For Completed Matter claim, using Child Migrant ECS for Immigration
+   Given the following Matter Types are chosen:
+    | IMXL:IOUT |
+   When the following outcomes are bulkloaded:
+      | # | UFN          | CLAIM_TYPE | CASE_START_DATE | WORK_CONCLUDED_DATE |  PROFIT_COST | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT | COUNSEL_COST  | EXEMPTION_CRITERIA_SATISFIED  | VAT_INDICATOR |
+      | 1 | 010120/001   | CM         | 01/01/2020      | 31/03/2020          |  3000.00     | 3000.00              | 600.00            | 3000.00       |             CM001             |       Y       |
+      | 3 | 010120/002   | CM         | 01/01/2020      | 31/03/2020          |  1500.00     | 1000.00              | 200.00            | 500.00        |             CM001             |       N       |
+   When user confirms the submission
+   And user is on the pricing outcome details page
+   Then user should see the following outcomes:
+      | # | UFN        | Value         |
+      | 1 | 010120/001 | £ 10,800.00   |
+      | 2 | 010120/002 | £ 3,200.00    |


### PR DESCRIPTION
## What does this pull request do?

removed the old tests and added new tests for child migrant max cap removal. It's for immigration and asylum

## Why make these changes?

To test if the max price cap is removed for child migrant cases in the Immigration and asylum area of law.

## Checklist
https://dsdmoj.atlassian.net/browse/TA-1556
