### PR TITLE
reduce cpu core to 1

### DIFF
--- a/charts/cwa-tests/templates/pod.yml
+++ b/charts/cwa-tests/templates/pod.yml
@@ -18,7 +18,7 @@ spec:
       value: {{ .Values.global.test_env }}
     resources:
       requests:
-        cpu: 4000m
+        cpu: 1000m
         memory: 8192Mi
       limits:
         cpu: 4000m


### PR DESCRIPTION
## What does this pull request do?

reduce cpu usage in the kubernetes cluster

##Why make these changes?

platform team has advised reducing the standard limit on cpu cores as its too much load on the cluster

## Checklist

No ticket. As its a simple change