### PR TITLE
TA-2473 - new page definitions and step definitions to allow testing of submission screens

### DIFF
--- a/features/step_definitions/cwa_navigation_steps.rb
+++ b/features/step_definitions/cwa_navigation_steps.rb
@@ -55,3 +55,25 @@ end
 Then('their submission details are displayed') do
   expect(page).to have_title("Submission Details", wait:20)
 end
+
+When('the user navigates to the submission review screen') do
+  expect(page.title).to eq("Submission Details")
+  submission_details_page = SubmissionDetailsPage.new
+  submission_details_page.next_button.double_click
+  expect(page).to have_title("Submission Review", wait:20)
+  @submission_page = SubmissionReviewPage.new
+end
+
+When('the user navigates to the submission summary screen') do
+  expect(page.title).to eq("Submission Details").or eq("Submission Review")
+  #if page is Submission Details then go to submission review
+  if page.title == "Submission Details"
+    steps %(
+      When the user navigates to the submission review screen
+    )
+  end
+  submission_review_page = SubmissionReviewPage.new
+  submission_review_page.next_button.double_click
+  expect(page).to have_title("Submission Summary", wait:20)
+  @submission_page = SubmissionSummaryPage.new
+end

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -140,3 +140,8 @@ Then("the outcome does not save and this popup error appears:") do |string|
   expect(page.driver.browser.switch_to.alert.text).to have_content(string)
   page.driver.browser.switch_to.alert.dismiss
 end
+
+Then('the no. of reported outcomes is {int}') do |no_reported_outcomes|
+  expect(page.title).to eq("Submission Review").or eq("Submission Summary")
+  expect(@submission_page.summary_section.outcomes).to have_content(no_reported_outcomes)
+end

--- a/features/support/ui/sections/submission_button_section.rb
+++ b/features/support/ui/sections/submission_button_section.rb
@@ -1,0 +1,9 @@
+class SubmissionButtonSection < SitePrism::Section
+    set_default_search_arguments '#PageButtons'
+
+    element :outcome_pricing_details_button, 'button[id="PricingDetails"]'
+    element :printable_page_button, 'button[id="Print"]'
+    element :export_button, 'button[id="Export"]'
+    element :save_button, 'button[id="Save"]'
+    element :submit_button, 'button[id="Submit"]'
+end

--- a/features/support/ui/sections/submission_header_section.rb
+++ b/features/support/ui/sections/submission_header_section.rb
@@ -1,0 +1,10 @@
+class SubmissionHeaderSection < SitePrism::Section
+    set_default_search_arguments '#SubmissionHeaderRN'
+
+    element :firm_name, :xpath, '//span[@id="FirmName"]'
+    element :account_number, :xpath, '//span[@id="LscAccountNumber"]'
+    element :office, :xpath, '//span[@id="Office"]'
+    element :submission_period, :xpath, '//span[@id="SubmissionPeriod"]' 
+    element :schedule_submission_reference, :xpath, '//span[@id="Schedule"]' 
+    element :submission_type, :xpath, '//span[@id="AreaOfLaw"]' 
+end

--- a/features/support/ui/sections/submission_summary_section.rb
+++ b/features/support/ui/sections/submission_summary_section.rb
@@ -1,0 +1,9 @@
+class SubmissionSummarySection < SitePrism::Section
+    set_default_search_arguments '#SummaryDetailsRN'
+   
+    element :outcomes, '#N3\:Numberofoutcomes\:0'
+    element :total_reported_profit_costs, '#N3\:ProfitCosts\:0'
+    element :total_reported_disbursement_costs, '#N3\:Disbursements\:0'
+    element :total_reported_counsel_costs, '#N3\:CounselCosts\:0'
+    element :total_reported_costs, '#N3\:Total\:0'
+end

--- a/features/support/ui/submission_details_page.rb
+++ b/features/support/ui/submission_details_page.rb
@@ -1,3 +1,5 @@
+require_relative 'sections/submission_button_section.rb'
+
 class SubmissionDetailsOutcomeSection < SitePrism::Section
   element :select_checkbox, :xpath, "*/input[@title = 'Select']"
   element :ufn, :xpath, ".//*[contains(@title,'UFN')]"
@@ -19,4 +21,8 @@ class SubmissionDetailsPage < SitePrism::Page
   def select_all
     outcomes.map { |outcome| outcome.select_checkbox.click }
   end
+
+  section :submission_button_section, SubmissionButtonSection
+
+  element :next_button, :xpath, '//*[@id="PageButtons"]/tbody/tr[1]/td[10]/button'
 end

--- a/features/support/ui/submission_review_path.rb
+++ b/features/support/ui/submission_review_path.rb
@@ -1,0 +1,12 @@
+require_relative 'sections/submission_button_section.rb'
+require_relative 'sections/submission_header_section.rb'
+require_relative 'sections/submission_summary_section.rb'
+
+class SubmissionReviewPage < SitePrism::Page
+    section :header_section, SubmissionHeaderSection
+    section :button_section, SubmissionButtonSection
+    section :summary_section, SubmissionSummarySection
+
+    element :next_button, :xpath, '//*[@id="PageButtons"]/tbody/tr[1]/td[12]/button'
+    element :back_button, :xpath, '//*[@id="PageButtons"]/tbody/tr[1]/td[8]/button'
+end

--- a/features/support/ui/submission_summary_page.rb
+++ b/features/support/ui/submission_summary_page.rb
@@ -1,0 +1,36 @@
+require_relative 'sections/submission_button_section.rb'
+require_relative 'sections/submission_header_section.rb'
+require_relative 'sections/submission_summary_section.rb'
+
+# class SubmissionSummaryNmsCivilSection < SitePrism::Section
+#     set_default_search_arguments '#NewMatterStartsTableCivil'
+    
+#     elements :category, 'span[title="Category"]'
+#     elements :schedule_reference, 'span[title="Schedule Reference"]'
+#     elements :access_point, 'span[title="Access Point"]'
+#     elements :procurement_area, 'span[title="Procurement Area"]'
+#     elements :delivery_location, :xpath, @@table_base + './/td[5]'
+#     elements :matter_starts, :xpath, @@table_base + './/td[6]'
+#     elements :recalculate_button, :xpath, @@table_base + './/td[7]'
+#     elements :matter_starts_total, :xpath, @@table_base + './/td[8]'
+# end
+
+# class SubmissionSummaryNmsCrimeSection < SitePrism::Section
+#     set_default_search_arguments '#NewMatterStartsTableCrime'
+
+#     elements :stage_reached, :xpath, @@table_base + './/td[1]'
+#     elements :description, :xpath, @@table_base + './/td[2]'
+#     elements :controlled_work_reported_this_month, :xpath, @@table_base + './/td[3]'
+#     elements :total_value_work_reported_this_month, :xpath, @@table_base + './/td[4]'
+# end
+
+class SubmissionSummaryPage < SitePrism::Page
+    section :button_section, SubmissionButtonSection
+    section :header_section, SubmissionHeaderSection
+    section :summary_section, SubmissionSummarySection
+    
+    # section :nms_civil, SubmissionSummaryNmsCivilSection
+    # section :nms_crime, SubmissionSummaryNmsCrimeSection
+
+    element :back_button, :xpath, '//*[@id="PageButtons"]/tbody/tr[1]/td[10]/button'
+end

--- a/features/validations/legal_help/early_legal_advice/ela_manual_entry.feature
+++ b/features/validations/legal_help/early_legal_advice/ela_manual_entry.feature
@@ -10,3 +10,21 @@ Feature: validate case start date
     |     212 | LHPC:LHAC   | HP00001          | AP00000      | LA            | LB           |      01/04/2024 |
 
     Then the outcome saves successfully
+
+  @delete_outcome_after @manual_submission
+  Scenario Outline: Manual entry for EARLY LEGAL ADVICE
+    When user adds outcomes for "Legal Help" "early_legal_advice" with fields like this:
+    | case_id | matter_type | procurement_area | access_point | stage_reached | outcome_code | case_start_date |
+    |     213 | LHPC:LHAC   | HP00001          | AP00000      | LA            | LB           |      01/04/2024 |
+    And the outcome saves successfully
+    And the user navigates to the submission review screen
+    Then the no. of reported outcomes is 1
+
+  @delete_outcome_after @manual_submission
+  Scenario Outline: Manual entry for EARLY LEGAL ADVICE
+    When user adds outcomes for "Legal Help" "early_legal_advice" with fields like this:
+    | case_id | matter_type | procurement_area | access_point | stage_reached | outcome_code | case_start_date |
+    |     214 | LHPC:LHAC   | HP00001          | AP00000      | LA            | LB           |      01/04/2024 |
+    And the outcome saves successfully
+    And the user navigates to the submission summary screen
+    Then the no. of reported outcomes is 1


### PR DESCRIPTION
## What does this pull request do?
Mods and additions to allow feature tests of additional submission screens (review and summary)

Please describe what you did.
*cwa_navigation_steps.rb*
- 2 new step definitions which allow navigation to the Submission Review and Submission Summary pages.

*submission_review.rb, submission_summary.rb*
- 2 new page definitions

*submission_details.rb*
- minor mod to existing definition

*/sections*
- many of the UI sections on the Submission Review and Submission Summary pages which are largely shared have been defined as SitePrism::Sections and the relevant files moved into a /sections folder for better organisation.
- SubmissionButtonSection.rb
  Defines common buttons on the Submission Review/Summary screen.
- SubmssionSummarySection.rb
  Defines fields which appear in the Summary Section on the Submission Review/Summary screens.
- SubmissionHeaderSection.rb
  Defines fields which display Office/Submission Month info on the Submission Review/Summary screens.

*cwa_outcome_steps.rb* 
- simple step definition to check the no. of reported outcomes field is correct given created submissions.

*ela_manual_entry.rb*
- 2 simple tests to sanity check some of the new buttons/fields defined in the page definitions.

## Why make these changes?
Please describe why the changes were needed.
Needed to add definition files to allow future testing of additional submission screens.

## Checklist

- [x] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-2473
