### PR TITLE
Modify XMLBuilder module to allow the injection of newMatterStarts XML data from feature tests

### DIFF
--- a/features/step_definitions/bulk_load_steps.rb
+++ b/features/step_definitions/bulk_load_steps.rb
@@ -235,3 +235,26 @@ When("user views the submission details") do
   @bulk_load_results_page = BulkLoadResultsPage.new
   @bulk_load_results_page.submissions.first.bulk_load_update_link.click
 end
+
+Given('the following outcomes are added to the bulkload file:') do |table|
+  # table is a Cucumber::MultilineArgument::DataTable
+  @xml = prepare_bulkload_xml(
+    submission: @submission,
+    matter_types: @matter_types,
+    new_lines: table_to_hash_array(table)
+  )
+end
+
+And('the bulkload file is submitted') do
+  @bulk_load_page = BulkLoadPage.new
+  expect(page).to have_content("Bulk Load File Selection", wait: 5)
+  file_name = save_tmp_bulkload_xml(@xml.raw)
+  @bulk_load_page.bulk_load_file.send_keys(file_name)
+  @bulk_load_page.wait_until_next_button_visible(wait: 5)
+  @bulk_load_page.next_button.double_click
+end
+
+And('the following new matter starts are added to the bulkload file:') do |table|
+  nms_data = table.hashes
+  @xml.add_nms_data(nms_data)
+end

--- a/features/support/helpers/bulkload.rb
+++ b/features/support/helpers/bulkload.rb
@@ -27,6 +27,10 @@ module Helpers
       Helpers::XMLBuilder::XML.new(submission: submission, matter_types: matter_types, new_lines: new_lines).raw
     end
 
+    def prepare_bulkload_xml(submission:, matter_types:, new_lines:)
+      Helpers::XMLBuilder::XML.new(submission: submission, matter_types: matter_types, new_lines: new_lines)
+    end
+
     def parse_bulkload_xml(file_name)
       Nokogiri::Slop(File.read(bulkload_file_path(file_name))).remove_namespaces!
     end

--- a/features/support/helpers/nms.rb
+++ b/features/support/helpers/nms.rb
@@ -1,0 +1,34 @@
+module Helpers
+	module XMLBuilder
+		class NewMatterStartsXML
+			def initialize(sr, pa, ap, col, nms)
+				#@sr, @pa, @ap, @col, @nms = *argList
+				@sr = sr
+				@pa = pa
+				@ap = ap
+				@col = col
+				@nms = nms
+			end
+			#SCHEDULE_REF tag
+			def sr_tag
+					"<matterStart code=\"SCHEDULE_REF\">#{@sr}</matterStart>"
+			end
+			#PROCUREMENT_AREA tag
+			def pa_tag
+					"<matterStart code=\"PROCUREMENT_AREA\">#{@pa}</matterStart>"
+			end
+			#ACCESS_POINT tag
+			def ap_tag
+					"<matterStart code=\"ACCESS_POINT\">#{@ap}</matterStart>"
+			end
+			#CATEGORY_OF_LAW/NMS tag
+			def col_tag
+					"<matterStart code=\"#{@col}\">#{@nms}</matterStart>"
+			end
+			#newMatterStarts Section
+			def section_tag
+					"<newMatterStarts>#{sr_tag}#{pa_tag}#{ap_tag}#{col_tag}</newMatterStarts>"
+			end
+		end
+	end
+end

--- a/features/support/helpers/xml_builder.rb
+++ b/features/support/helpers/xml_builder.rb
@@ -18,6 +18,10 @@ module Helpers
         @xml
       end
 
+      def doc
+        Nokogiri::HTML::DocumentFragment.parse @xml
+      end
+
       def initialise_builder
         @builder = Builder::XmlMarkup.new(indent: 2)
         @builder.instruct!
@@ -55,6 +59,22 @@ module Helpers
 
       def default_field_value(name)
         @submission.lines.find { |d| d.name == name }&.default_value
+      end
+
+      def add_nms_data(new_matter_starts)
+        doc = Nokogiri::XML(self.raw)
+        schedule = doc.search('schedule').last
+        new_matter_starts.each { |n|
+          nms = NewMatterStartsXML.new(
+              n['schedule_ref'],
+              n['procurement_area'], 
+              n['access_point'],
+              n['category_of_law'], 
+              n['nms']
+          )
+          schedule.add_child(nms.section_tag)
+        }
+        @xml = doc
       end
 
       def generate_outcome(new_line, tot_outcomes, outcome)

--- a/features/validations/legal_help/early_legal_advice/NMS_validation.feature
+++ b/features/validations/legal_help/early_legal_advice/NMS_validation.feature
@@ -1,3 +1,25 @@
+# Commenting out these tests until we have clarity on how to test NMS data in a bulkload file
+
+# @bulkload
+# Feature: Early Legal Advice validations with New Matter Starts
+
+#   Background: 
+#     Given a test firm user is logged in CWA
+#     And user prepares to submit outcomes for test provider "LEGAL HELP.ELA#17"
+    
+#   @valid @nms
+#   Scenario: Bulkload Early Legal Advice outcomes with NMS data
+#     Given the following Matter Types are chosen:
+#     | LHPC:LHAC |
+#     And the following outcomes are added to the bulkload file:
+#     | # | CASE_START_DATE | CLAIM_TYPE | OUTCOME_CODE | PROCUREMENT_AREA | STAGE_REACHED | 
+#     | 1 |      02/06/2019 | CM         | LB           | HP00016          | LA            |
+#     And the following new matter starts are added to the bulkload file:
+#     | schedule_ref      | procurement_area | access_point | category_of_law | nms |
+#     | 01/2Q389Q/2018/18 | HP00016          | AP00000      | ELA             | 10  |
+#     And the bulkload file is submitted
+#     Then successful outcomes should equal 1
+
 # Commenting out these tests until we have clarity on TA-2643 ticket. 
 
 # Feature: validate NMS with PA ,case start date and schedule start/end dates


### PR DESCRIPTION
## What does this pull request do?

Please describe what you did.
- New step def's in **bulk_load_steps.rb** to
  - add outcomes to the bulkload file without submitting
  - separately submit a bulkload file
  - add matter starts data from a feature test table into an existing bulkload file

- New method in **bulkload.rb** to prepare the bulkload file without submitting it

- Simple **nms.rb** class which builds the newMatterStarts XML for given data

- changes to **xml_builder.rb** to assign the raw XML to a Nokogiri variable so we can easily use Nokogiri methods to find the insertion point for the newMatterStarts section and inject it.

- mockup test (commented out for now) to test that we can inject newMatterStarts data from a feature test table into the bulkload file

## Why make these changes?

Please describe why the changes were needed.
There was existing method to add newMatterStarts data to the test bulkload file.

## Checklist

- [x] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-2770
