### PR TITLE
TA-2908 Youth Court code validation

### DIFF
--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -24,7 +24,7 @@ Then('the outcome saves successfully') do
 end
 
 
-When("user adds outcomes for {string} {string} with fields like this for dulplicate claims:") do |area_of_law, category_of_law, table|
+When("user adds outcomes for {string} {string} with fields like this for duplicate claims:") do |area_of_law, category_of_law, table|
   outcome_data = table.hashes
   @submissions_saved = outcome_data.size
   outcome_data.each do |outcome|

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -98,31 +98,31 @@ When("user adds outcomes for {string} {string} with fields like this again:") do
 end
 
 When ("user adds an outcome for {string} {string} with {string}, {string}, {string}, {string}, {string}, {string} and {string}") do |area_of_law, category_of_law, case_id, matter_type, ecs, ecf_ref, case_start_date, pa, ap |
-    sr = CWAProvider.submission.schedule_ref
+  sr = CWAProvider.submission.schedule_ref
 
-    outcome_data = Hash.new
+  outcome_data = Hash.new
 
-    outcome_data["matter_type"] = matter_type
-    outcome_data["excl_case_funding_ref"] = ecf_ref
-    outcome_data["case_start_date"] = case_start_date
-    outcome_data["procurement_area"] = pa
-    outcome_data["access_point"] = ap
-    outcome_data["case_id"] = case_id
-    outcome_data["exemption_criteria_satisfied"] = ecs
+  outcome_data["matter_type"] = matter_type
+  outcome_data["excl_case_funding_ref"] = ecf_ref
+  outcome_data["case_start_date"] = case_start_date
+  outcome_data["procurement_area"] = pa
+  outcome_data["access_point"] = ap
+  outcome_data["case_id"] = case_id
+  outcome_data["exemption_criteria_satisfied"] = ecs
 
-    submission_list_page = SubmissionListPage.new
-    submission_list_page.add_outcome_button.click
-    
-    outcome_data["schedule_ref"] = sr
-    builder = Helpers::ScreenFieldBuilder.from(
-      area_of_law: area_of_law.downcase.gsub(' ', '_'),
-      category_of_law: category_of_law.downcase.gsub(' ', '_')
-    )
+  submission_list_page = SubmissionListPage.new
+  submission_list_page.add_outcome_button.click
+  
+  outcome_data["schedule_ref"] = sr
+  builder = Helpers::ScreenFieldBuilder.from(
+    area_of_law: area_of_law.downcase.gsub(' ', '_'),
+    category_of_law: category_of_law.downcase.gsub(' ', '_')
+  )
 
-    builder.overrides = outcome_data
-    page = AddOutcomePage.new(builder)
-    page.add_outcome
-  end
+  builder.overrides = outcome_data
+  page = AddOutcomePage.new(builder)
+  page.add_outcome
+end
 
   When("user enters an outcome for {string} {string} with fields like this:") do |area_of_law, category_of_law, table|
     submission_details_page = SubmissionDetailsPage.new

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -24,7 +24,7 @@ Then('the outcome saves successfully') do
 end
 
 
-  When("user adds outcomes for {string} {string} with fields like this for dulplicate claims:") do |area_of_law, category_of_law, table|
+When("user adds outcomes for {string} {string} with fields like this for dulplicate claims:") do |area_of_law, category_of_law, table|
     outcome_data = table.hashes
     @submissions_saved = outcome_data.size
     outcome_data.each do |outcome|
@@ -64,7 +64,7 @@ When("user adds outcomes for {string} {string} with fields like this:") do |area
       claim_type: outcome['claim_type']
     )
     if !outcome.has_key?("schedule_ref")
-            outcome['schedule_ref'] = CWAProvider.submission.schedule_ref
+      outcome['schedule_ref'] = CWAProvider.submission.schedule_ref
     end
     if !outcome.has_key?("case_start_date") && !(area_of_law == "Crime Lower")
       outcome['case_start_date'] = (Date.today + 1).strftime("%d-%b-%Y") 
@@ -124,6 +124,39 @@ When ("user adds an outcome for {string} {string} with {string}, {string}, {stri
     page.add_outcome
   end
 
+  When("user enters an outcome for {string} {string} with fields like this:") do |area_of_law, category_of_law, table|
+    submission_details_page = SubmissionDetailsPage.new
+    if !submission_details_page.has_text?(/No results found/)
+      STDOUT.print 'Cleaning existing outcomes for test reference...'
+      submission_details_page.select_all
+      submission_details_page.delete_button.click
+      submission_details_page.confirm_delete_button.click
+      STDOUT.puts ' done.'
+    end
+    outcome_data = table.hashes
+    @submissions_saved = outcome_data.size
+    outcome_data.each do |outcome|
+      submission_list_page = SubmissionListPage.new
+      submission_list_page.add_outcome_button.click
+      builder = Helpers::ScreenFieldBuilder.from(
+        category_of_law: category_of_law.downcase.gsub(' ', '_'),
+        area_of_law: area_of_law.downcase.gsub(' ', '_'),
+        matter_type: outcome['matter_type'],
+        claim_type: outcome['claim_type']
+      )
+      if !outcome.has_key?("schedule_ref")
+        outcome['schedule_ref'] = CWAProvider.submission.schedule_ref
+      end
+      if !outcome.has_key?("case_start_date") && !(area_of_law == "Crime Lower")
+        outcome['case_start_date'] = (Date.today + 1).strftime("%d-%b-%Y") 
+      end
+      builder.overrides = outcome
+  
+      page = AddOutcomePage.new(builder)
+      page.add_outcome(click_save_button: false)
+    end
+  end
+
 Then("the outcome does not save and gives an error containing:") do |string|
   page = AddOutcomePage.new
   expect(page).to have_content('Error')
@@ -137,11 +170,24 @@ Then("the outcome does not save and the error message {string} appears") do |err
 end
 
 Then("the outcome does not save and this popup error appears:") do |string|
-  expect(page.driver.browser.switch_to.alert.text).to have_content(string)
-  page.driver.browser.switch_to.alert.dismiss
+  wait = Selenium::WebDriver::Wait.new(timeout: 10) # Wait for up to 10 seconds
+
+  alert = wait.until { page.driver.browser.switch_to.alert }
+  expect(alert.text).to have_content(string)
+  alert.dismiss
+rescue Selenium::WebDriver::Error::TimeoutError
+  raise "Expected alert with message '#{string}' but no alert appeared within the timeout period"
 end
 
 Then('the no. of reported outcomes is {int}') do |no_reported_outcomes|
   expect(page.title).to eq("Submission Review").or eq("Submission Summary")
   expect(@submission_page.summary_section.outcomes).to have_content(no_reported_outcomes)
+end
+
+Then('the drop down list {string} contains the following values:') do |string, table|
+  page = AddOutcomePage.new
+  actual_values = page.dropdown_options(string)
+  #remove nil value entries before testing values
+  filtered_array = actual_values.reject { |item| item.empty? }
+  expect(filtered_array).to match_array(table.raw.flatten)
 end

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -25,23 +25,23 @@ end
 
 
 When("user adds outcomes for {string} {string} with fields like this for dulplicate claims:") do |area_of_law, category_of_law, table|
-    outcome_data = table.hashes
-    @submissions_saved = outcome_data.size
-    outcome_data.each do |outcome|
-      submission_list_page = SubmissionListPage.new
-      submission_list_page.add_outcome_button.click
-      builder = Helpers::ScreenFieldBuilder.from(
-        category_of_law: category_of_law.downcase.gsub(' ', '_'),
-        area_of_law: area_of_law.downcase.gsub(' ', '_'),
-        matter_type: outcome['matter_type'],
-        claim_type: outcome['claim_type']
-      )
-      outcome['schedule_ref'] = CWAProvider.submission.schedule_ref
-      builder.overrides = outcome
-      page = AddOutcomePage.new(builder)
-      page.add_outcome
-    end
+  outcome_data = table.hashes
+  @submissions_saved = outcome_data.size
+  outcome_data.each do |outcome|
+    submission_list_page = SubmissionListPage.new
+    submission_list_page.add_outcome_button.click
+    builder = Helpers::ScreenFieldBuilder.from(
+      category_of_law: category_of_law.downcase.gsub(' ', '_'),
+      area_of_law: area_of_law.downcase.gsub(' ', '_'),
+      matter_type: outcome['matter_type'],
+      claim_type: outcome['claim_type']
+    )
+    outcome['schedule_ref'] = CWAProvider.submission.schedule_ref
+    builder.overrides = outcome
+    page = AddOutcomePage.new(builder)
+    page.add_outcome
   end
+end
 
 When("user adds outcomes for {string} {string} with fields like this:") do |area_of_law, category_of_law, table|
   submission_details_page = SubmissionDetailsPage.new

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -153,7 +153,7 @@ When("user enters an outcome for {string} {string} with fields like this:") do |
     builder.overrides = outcome
 
     page = AddOutcomePage.new(builder)
-    page.add_outcome(click_save_button: false)
+    page.add_outcome(false)
   end
 end
 

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -124,38 +124,38 @@ When ("user adds an outcome for {string} {string} with {string}, {string}, {stri
   page.add_outcome
 end
 
-  When("user enters an outcome for {string} {string} with fields like this:") do |area_of_law, category_of_law, table|
-    submission_details_page = SubmissionDetailsPage.new
-    if !submission_details_page.has_text?(/No results found/)
-      STDOUT.print 'Cleaning existing outcomes for test reference...'
-      submission_details_page.select_all
-      submission_details_page.delete_button.click
-      submission_details_page.confirm_delete_button.click
-      STDOUT.puts ' done.'
-    end
-    outcome_data = table.hashes
-    @submissions_saved = outcome_data.size
-    outcome_data.each do |outcome|
-      submission_list_page = SubmissionListPage.new
-      submission_list_page.add_outcome_button.click
-      builder = Helpers::ScreenFieldBuilder.from(
-        category_of_law: category_of_law.downcase.gsub(' ', '_'),
-        area_of_law: area_of_law.downcase.gsub(' ', '_'),
-        matter_type: outcome['matter_type'],
-        claim_type: outcome['claim_type']
-      )
-      if !outcome.has_key?("schedule_ref")
-        outcome['schedule_ref'] = CWAProvider.submission.schedule_ref
-      end
-      if !outcome.has_key?("case_start_date") && !(area_of_law == "Crime Lower")
-        outcome['case_start_date'] = (Date.today + 1).strftime("%d-%b-%Y") 
-      end
-      builder.overrides = outcome
-  
-      page = AddOutcomePage.new(builder)
-      page.add_outcome(click_save_button: false)
-    end
+When("user enters an outcome for {string} {string} with fields like this:") do |area_of_law, category_of_law, table|
+  submission_details_page = SubmissionDetailsPage.new
+  if !submission_details_page.has_text?(/No results found/)
+    STDOUT.print 'Cleaning existing outcomes for test reference...'
+    submission_details_page.select_all
+    submission_details_page.delete_button.click
+    submission_details_page.confirm_delete_button.click
+    STDOUT.puts ' done.'
   end
+  outcome_data = table.hashes
+  @submissions_saved = outcome_data.size
+  outcome_data.each do |outcome|
+    submission_list_page = SubmissionListPage.new
+    submission_list_page.add_outcome_button.click
+    builder = Helpers::ScreenFieldBuilder.from(
+      category_of_law: category_of_law.downcase.gsub(' ', '_'),
+      area_of_law: area_of_law.downcase.gsub(' ', '_'),
+      matter_type: outcome['matter_type'],
+      claim_type: outcome['claim_type']
+    )
+    if !outcome.has_key?("schedule_ref")
+      outcome['schedule_ref'] = CWAProvider.submission.schedule_ref
+    end
+    if !outcome.has_key?("case_start_date") && !(area_of_law == "Crime Lower")
+      outcome['case_start_date'] = (Date.today + 1).strftime("%d-%b-%Y") 
+    end
+    builder.overrides = outcome
+
+    page = AddOutcomePage.new(builder)
+    page.add_outcome(click_save_button: false)
+  end
+end
 
 Then("the outcome does not save and gives an error containing:") do |string|
   page = AddOutcomePage.new

--- a/features/support/ui/add_outcome_page.rb
+++ b/features/support/ui/add_outcome_page.rb
@@ -20,7 +20,7 @@ class AddOutcomePage < SitePrism::Page
   PRIMARY_FIELDS = %i[matter_type crime_matter_type claim_type].freeze
   private_constant :PRIMARY_FIELDS
 
-  def add_outcome(click_save_button: true)
+  def add_outcome(click_save_button = true)
     raise StandardError, "Cannot invoke method without defining 'builder' first" unless builder
 
     values = builder.values

--- a/features/support/ui/add_outcome_page.rb
+++ b/features/support/ui/add_outcome_page.rb
@@ -20,7 +20,7 @@ class AddOutcomePage < SitePrism::Page
   PRIMARY_FIELDS = %i[matter_type crime_matter_type claim_type].freeze
   private_constant :PRIMARY_FIELDS
 
-  def add_outcome
+  def add_outcome(click_save_button: true)
     raise StandardError, "Cannot invoke method without defining 'builder' first" unless builder
 
     values = builder.values
@@ -37,7 +37,12 @@ class AddOutcomePage < SitePrism::Page
     end
 
     page.execute_script "window.scrollBy(0,10000)"
-    save_button.click
+    save_button.click if click_save_button
+  end
+
+  def dropdown_options(dropdown_name)
+    dropdown = send(dropdown_name)
+    dropdown.all('option').map(&:text)
   end
 
   private
@@ -47,8 +52,16 @@ class AddOutcomePage < SitePrism::Page
 
     raise NotImplementedError, "Element '#{field}' is not defined on the page" unless respond_to?(field)
 
-    unless public_send("wait_until_#{field}_visible", wait: 5)
-      raise SitePrism::ElementVisibilityTimeoutError, "Element '#{field}' is not visible"
+    begin
+      unless public_send("wait_until_#{field}_visible", wait: 5)
+        raise SitePrism::ElementVisibilityTimeoutError, "Element '#{field}' is not visible"
+      end
+    rescue NoMethodError => e
+      puts "Caught a NoMethodError: #{e.message}"
+      raise
+    rescue SitePrism::ElementVisibilityTimeoutError => e
+      puts "Caught an ElementVisibilityTimeoutError: Element '#{field}' is not visible"
+      raise
     end
 
     element = public_send(field)

--- a/features/validations/crime_lower/criminal_proceedings/proe_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/proe_validations.feature
@@ -1,0 +1,27 @@
+
+  Feature: PROE code Manual and Bulk load validations
+  
+  @manual_submission
+  Scenario: Manually enter PROE outcomes and test some drop down lists are correct
+    Given user is on their "CRIME LOWER" submission details page
+    When user enters an outcome for "Crime Lower" "criminal proceedings" with fields like this:
+      | matter_type |
+      | PROE        |
+    Then the drop down list "crime_matter_type" contains the following values:
+      | 1-Offences against the person                                                      |
+      | 2-Homicide and related grave offences                                              |
+      | 3-Sexual offences and associated offences against children                         |
+      | 4-Robbery                                                                          |
+      | 5-Burglary                                                                         |
+      | 6-Criminal damage                                                                  |
+      | 7-Theft (including taking vehicle without consent)                                 |
+      | 8-Fraud and forgery and other offences of dishonesty not otherwise categorised     |
+      | 9-Public order offences                                                            |
+      | 10-Drug offences                                                                   |
+      | 11-Driving and motor vehicle offences (other than those covered by codes 1, 6 & 7) |
+      | 12-Other offences                                                                  |
+      | 13-Terrorism                                                                       |
+      | 14-Anti-social behaviour orders                                                    |
+      | 15-Sexual offender orders                                                          |
+      | 16-Other prescribed proceedings                                                    |
+      | 36-Breach of part 1 Injunctions under the ASBCP Act 2014                           |

--- a/features/validations/crime_lower/criminal_proceedings/youe_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youe_validations.feature
@@ -2,15 +2,15 @@ Feature: YOUE code Manual and Bulk load validations
 
   @bullkload_submission
   Scenario: Bulkoad Crime Lower stage reached code YOUE with case outcome code CP19
-  is invalid for YOUE
+    is invalid for YOUE
 
     Given a test firm user is logged in CWA
     And user prepares to submit outcomes for test provider "CRIME LOWER#8"
     Given the following Matter Types are chosen:
       | YOUE |
     And the following outcomes are bulkloaded:
-      | # | UFN        | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION |NUMBER_OF_POLICE_STATION|
-      | 1 | 010924/001 | CP19         |           01/9/2024 | Y           | C1013          |1                       |
+      | # | UFN        | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION |
+      | 1 | 010924/001 | CP19         |           01/9/2024 | Y           | C1013          |                        1 |
     Then the following results are expected:
       | # | ERROR_CODE_OR_MESSAGE            |
       | 1 | CP19 is not a valid OUTCOME_CODE |
@@ -19,9 +19,59 @@ Feature: YOUE code Manual and Bulk load validations
   Scenario: Manually enter YOUE outcomes using the mag court fee scheme 01-JAN-1995 to 02-OCT-2011
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
-      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code |
-      | YOUE        |                |                  |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         |
+      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
+      | YOUE        | 28-OCT-2024    | 1A               |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         | 1234567 |
     Then the outcome does not save and gives an error containing:
       """
       Outcome Code - ID CP19 for the flexfield segment Outcome Code does not exist in the value set XXLSC_CASE_OUTCOME_CODE_CL.
       """
+  #YOU<a> court codes have a new screen to capture fields.  It is pretty much a close copy of the PRO<a>
+  #screen with some fields now being mandatory.  The following tests check that these fields are now being
+  #implemented as mandatory fields on the new screen.  They are as follows:-
+  # Representation Order Date
+  # MAAT ID
+  # Standard Fee Category
+  # On the manual screen a popup will warn the user if the fields are not completed.
+
+  @manual_submission
+  Scenario: Manually enter YOUE outcomes without certain mandatory fields completed
+    Given user is on their "CRIME LOWER" submission details page
+    When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
+      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
+      | YOUE        |                |                  |         100 | 010924/001 |         01-SEP-2024 | C1013          | CP18         |         |
+    Then the outcome does not save and this popup error appears:
+      """
+      A value must be entered for "Representation Order Date".
+      A value must be entered for "Standard Fee Category".
+      A value must be entered for "MAAT ID".
+      """
+
+  @manual_submission
+  Scenario: Manually enter YOUE outcomes and test some drop down lists are correct
+    Given user is on their "CRIME LOWER" submission details page
+    When user enters an outcome for "Crime Lower" "criminal proceedings" with fields like this:
+      | matter_type |
+      | YOUE        |
+    Then the drop down list "standard_fee_cat" contains the following values:
+      | Category 1A |
+      | Category 1B |
+      | Category 2A |
+      | Category 2B |
+    And the drop down list "crime_matter_type" contains the following values:
+      | 1-Offences against the person                                                      |
+      | 2-Homicide and related grave offences                                              |
+      | 3-Sexual offences and associated offences against children                         |
+      | 4-Robbery                                                                          |
+      | 5-Burglary                                                                         |
+      | 6-Criminal damage                                                                  |
+      | 7-Theft (including taking vehicle without consent)                                 |
+      | 8-Fraud and forgery and other offences of dishonesty not otherwise categorised     |
+      | 9-Public order offences                                                            |
+      | 10-Drug offences                                                                   |
+      | 11-Driving and motor vehicle offences (other than those covered by codes 1, 6 & 7) |
+      | 12-Other offences                                                                  |
+      | 13-Terrorism                                                                       |
+      | 14-Anti-social behaviour orders                                                    |
+      | 15-Sexual offender orders                                                          |
+      | 16-Other prescribed proceedings                                                    |
+      | 36-Breach of part 1 Injunctions under the ASBCP Act 2014                           |

--- a/features/validations/crime_lower/criminal_proceedings/youf_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youf_validations.feature
@@ -19,9 +19,60 @@ Feature: YOUF code Manual and Bulk load validations
   Scenario: Manually enter YOUF outcomes using the mag court fee scheme 01-JAN-1995 to 02-OCT-2011
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
-      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code |
-      | YOUF        |                |                  |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         |
+      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
+      | YOUF        | 28-OCT-2024    | 1B               |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         | 1234567 |
     Then the outcome does not save and gives an error containing:
       """
       Outcome Code - ID CP19 for the flexfield segment Outcome Code does not exist in the value set XXLSC_CASE_OUTCOME_CODE_CL.
       """
+
+  #YOU<a> court codes have a new screen to capture fields.  It is pretty much a close copy of the PRO<a> 
+  #screen with some fields now being mandatory.  The following tests check that these fields are now being 
+  #implemented as mandatory fields on the new screen.  They are as follows:-
+  # Representation Order Date
+  # MAAT ID
+  # Standard Fee Category
+  # On the manual screen a popup will warn the user if the fields are not completed.
+  @manual_submission
+  Scenario: Manually enter YOUF outcomes without certain mandatory fields completed
+    Given user is on their "CRIME LOWER" submission details page
+    When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
+      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
+      | YOUF        |                |                  |         100 | 010924/001 |         01-SEP-2024 | C1013          | CP18         |         |
+    Then the outcome does not save and this popup error appears:
+      """
+      A value must be entered for "Representation Order Date".
+      A value must be entered for "Standard Fee Category".
+      A value must be entered for "MAAT ID".
+      """
+
+
+  @manual_submission
+  Scenario: Manually enter YOUF outcomes and test some drop down lists are correct
+    Given user is on their "CRIME LOWER" submission details page
+    When user enters an outcome for "Crime Lower" "criminal proceedings" with fields like this:
+      | matter_type |
+      | YOUF        |
+    Then the drop down list "standard_fee_cat" contains the following values:
+      | Category 1A |
+      | Category 1B |
+      | Category 2A |
+      | Category 2B |
+    And the drop down list "crime_matter_type" contains the following values:
+      | 1-Offences against the person                                                      |
+      | 2-Homicide and related grave offences                                              |
+      | 3-Sexual offences and associated offences against children                         |
+      | 4-Robbery                                                                          |
+      | 5-Burglary                                                                         |
+      | 6-Criminal damage                                                                  |
+      | 7-Theft (including taking vehicle without consent)                                 |
+      | 8-Fraud and forgery and other offences of dishonesty not otherwise categorised     |
+      | 9-Public order offences                                                            |
+      | 10-Drug offences                                                                   |
+      | 11-Driving and motor vehicle offences (other than those covered by codes 1, 6 & 7) |
+      | 12-Other offences                                                                  |
+      | 13-Terrorism                                                                       |
+      | 14-Anti-social behaviour orders                                                    |
+      | 15-Sexual offender orders                                                          |
+      | 16-Other prescribed proceedings                                                    |
+      | 36-Breach of part 1 Injunctions under the ASBCP Act 2014                           |

--- a/features/validations/crime_lower/criminal_proceedings/youk_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youk_validations.feature
@@ -19,9 +19,60 @@ Feature: YOUK code Manual and Bulk load validations
   Scenario: Manually enter YOUK outcomes using the mag court fee scheme 01-JAN-1995 to 02-OCT-2011
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
-      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code |
-      | YOUK        |                |                  |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         |
+      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
+      | YOUK        | 28-OCT-2024    | 1C               |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         | 1234567 |
     Then the outcome does not save and gives an error containing:
       """
       Outcome Code - ID CP19 for the flexfield segment Outcome Code does not exist in the value set XXLSC_CASE_OUTCOME_CODE_CL.
       """
+
+  #YOU<a> court codes have a new screen to capture fields.  It is pretty much a close copy of the PRO<a> 
+  #screen with some fields now being mandatory.  The following tests check that these fields are now being 
+  #implemented as mandatory fields on the new screen.  They are as follows:-
+  # Representation Order Date
+  # MAAT ID
+  # Standard Fee Category
+  # On the manual screen a popup will warn the user if the fields are not completed.
+  @manual_submission
+  Scenario: Manually enter YOUK outcomes without certain mandatory fields completed
+    Given user is on their "CRIME LOWER" submission details page
+    When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
+      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
+      | YOUK        |                |                  |         100 | 010924/001 |         01-SEP-2024 | C1013          | CP18         |         |
+    Then the outcome does not save and this popup error appears:
+      """
+      A value must be entered for "Representation Order Date".
+      A value must be entered for "Standard Fee Category".
+      A value must be entered for "MAAT ID".
+      """
+
+
+  @manual_submission
+  Scenario: Manually enter YOUE outcomes and test some drop down lists are correct
+    Given user is on their "CRIME LOWER" submission details page
+    When user enters an outcome for "Crime Lower" "criminal proceedings" with fields like this:
+      | matter_type |
+      | YOUL        |
+    Then the drop down list "standard_fee_cat" contains the following values:
+      | Category 1A |
+      | Category 1B |
+      | Category 2A |
+      | Category 2B |
+    And the drop down list "crime_matter_type" contains the following values:
+      | 1-Offences against the person                                                      |
+      | 2-Homicide and related grave offences                                              |
+      | 3-Sexual offences and associated offences against children                         |
+      | 4-Robbery                                                                          |
+      | 5-Burglary                                                                         |
+      | 6-Criminal damage                                                                  |
+      | 7-Theft (including taking vehicle without consent)                                 |
+      | 8-Fraud and forgery and other offences of dishonesty not otherwise categorised     |
+      | 9-Public order offences                                                            |
+      | 10-Drug offences                                                                   |
+      | 11-Driving and motor vehicle offences (other than those covered by codes 1, 6 & 7) |
+      | 12-Other offences                                                                  |
+      | 13-Terrorism                                                                       |
+      | 14-Anti-social behaviour orders                                                    |
+      | 15-Sexual offender orders                                                          |
+      | 16-Other prescribed proceedings                                                    |
+      | 36-Breach of part 1 Injunctions under the ASBCP Act 2014                           |

--- a/features/validations/crime_lower/criminal_proceedings/youl_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youl_validations.feature
@@ -19,9 +19,60 @@ Feature: YOUL code Manual and Bulk load validations
   Scenario: Manually enter YOUL outcomes using the mag court fee scheme 01-JAN-1995 to 02-OCT-2011
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
-      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code |
-      | YOUL        |                |                  |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         |
+      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
+      | YOUL        | 28-OCT-2024    | 1D               |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         | 1234567 |
     Then the outcome does not save and gives an error containing:
       """
       Outcome Code - ID CP19 for the flexfield segment Outcome Code does not exist in the value set XXLSC_CASE_OUTCOME_CODE_CL.
       """
+
+  #YOU<a> court codes have a new screen to capture fields.  It is pretty much a close copy of the PRO<a> 
+  #screen with some fields now being mandatory.  The following tests check that these fields are now being 
+  #implemented as mandatory fields on the new screen.  They are as follows:-
+  # Representation Order Date
+  # MAAT ID
+  # Standard Fee Category
+  # On the manual screen a popup will warn the user if the fields are not completed.
+  @manual_submission
+  Scenario: Manually enter YOUL outcomes without certain mandatory fields completed
+    Given user is on their "CRIME LOWER" submission details page
+    When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
+      | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
+      | YOUL        |                |                  |         100 | 010924/001 |         01-SEP-2024 | C1013          | CP18         |         |
+    Then the outcome does not save and this popup error appears:
+      """
+      A value must be entered for "Representation Order Date".
+      A value must be entered for "Standard Fee Category".
+      A value must be entered for "MAAT ID".
+      """
+
+
+  @manual_submission
+  Scenario: Manually enter YOUL outcomes and test some drop down lists are correct
+    Given user is on their "CRIME LOWER" submission details page
+    When user enters an outcome for "Crime Lower" "criminal proceedings" with fields like this:
+      | matter_type |
+      | YOUL        |
+    Then the drop down list "standard_fee_cat" contains the following values:
+      | Category 1A |
+      | Category 1B |
+      | Category 2A |
+      | Category 2B |
+    And the drop down list "crime_matter_type" contains the following values:
+      | 1-Offences against the person                                                      |
+      | 2-Homicide and related grave offences                                              |
+      | 3-Sexual offences and associated offences against children                         |
+      | 4-Robbery                                                                          |
+      | 5-Burglary                                                                         |
+      | 6-Criminal damage                                                                  |
+      | 7-Theft (including taking vehicle without consent)                                 |
+      | 8-Fraud and forgery and other offences of dishonesty not otherwise categorised     |
+      | 9-Public order offences                                                            |
+      | 10-Drug offences                                                                   |
+      | 11-Driving and motor vehicle offences (other than those covered by codes 1, 6 & 7) |
+      | 12-Other offences                                                                  |
+      | 13-Terrorism                                                                       |
+      | 14-Anti-social behaviour orders                                                    |
+      | 15-Sexual offender orders                                                          |
+      | 16-Other prescribed proceedings                                                    |
+      | 36-Breach of part 1 Injunctions under the ASBCP Act 2014                           |

--- a/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/IMMA_manual_duplicate_claims.feature
+++ b/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/IMMA_manual_duplicate_claims.feature
@@ -8,7 +8,7 @@ Feature: Validation for Illegal Immigration Act for duplicate claims for manual 
     When user adds outcomes for "Legal Help" "Immigration" with fields like this:
       | case_id | matter_type | case_start_date | excl_case_funding_ref | work_concluded_date | claim_type | ho_ucn   | ho_interview | outcome_code | procurement_area | access_point |
       |     001 | IMMA:IMRN   |      01/05/2023 |             1234567AB |          01/08/2023 | CM         | 12345678 |            0 | IA           | PA20000          | AP20000      |
-    When user adds outcomes for "Legal Help" "Immigration" with fields like this for dulplicate claims:
+    When user adds outcomes for "Legal Help" "Immigration" with fields like this for duplicate claims:
       | case_id | matter_type | case_start_date | excl_case_funding_ref | work_concluded_date | claim_type | ho_ucn   | ho_interview | outcome_code | procurement_area | access_point |
       |     001 | IMMA:IMRN   |      01/05/2023 |             1234567AB |          01/08/2023 | CM         | 12345678 |            0 | IA           | PA20000          | AP20000      |
     Then the outcome does not save and the error message "<error message>" appears
@@ -22,7 +22,7 @@ Feature: Validation for Illegal Immigration Act for duplicate claims for manual 
     When user adds outcomes for "Legal Help" "Immigration" with fields like this:
       | case_id | matter_type | case_start_date | excl_case_funding_ref | work_concluded_date | claim_type | ho_ucn   | ho_interview | outcome_code | procurement_area | access_point |
       |     001 | IMMA:IMRN   |      01/05/2023 |             1234567AB |          01/08/2023 | SC         | 12345678 |            0 | --           | PA20000          | AP20000      |
-    When user adds outcomes for "Legal Help" "Immigration" with fields like this for dulplicate claims:
+    When user adds outcomes for "Legal Help" "Immigration" with fields like this for duplicate claims:
       | case_id | matter_type | case_start_date | excl_case_funding_ref | work_concluded_date | claim_type | ho_ucn   | ho_interview | outcome_code | procurement_area | access_point |
       |     001 | IMMA:IMRN   |      01/05/2023 |             1234567AB |          01/08/2023 | SC         | 12345678 |            0 | --           | PA20000          | AP20000      |
     Then the outcome does not save and the error message "<error message>" appears
@@ -36,7 +36,7 @@ Feature: Validation for Illegal Immigration Act for duplicate claims for manual 
     When user adds outcomes for "Legal Help" "Immigration" with fields like this:
       | case_id | matter_type | case_start_date | excl_case_funding_ref | work_concluded_date | claim_type | ho_ucn   | ho_interview | outcome_code | procurement_area | access_point |
       |     001 | IMMA:IMRN   |      01/05/2023 |             1234567AB |          01/05/2023 | SC         | 12345678 |            0 | --           | PA20000          | AP20000      |
-    When user adds outcomes for "Legal Help" "Immigration" with fields like this for dulplicate claims:
+    When user adds outcomes for "Legal Help" "Immigration" with fields like this for duplicate claims:
       | case_id | matter_type | case_start_date | excl_case_funding_ref | work_concluded_date | claim_type | ho_ucn   | ho_interview | outcome_code | procurement_area | access_point |
       |     001 | IMMA:IMRN   |      01/05/2023 |             1234567AB |          01/08/2023 | DC         | 12345678 |            0 | --           | PA20000          | AP20000      |
     Then the outcome saves successfully


### PR DESCRIPTION
## What does this pull request do?

Please describe what you did.
```cwa_outcome_steps.rb```
- new dropdown list check method
- change to popup check method to ensure wait time is long enough to capture popup
- new sd so that outcomes can be entered and not saved to assist with screen checks i.e. dropdown values, etc...
- indentation corrections
- typo error (the word "duplicate")

```add_outcome_page.rb```
- pass an optional param to control whether the outcome is saved or not
- new ```dropdown_options``` method which can be used to check values in drop down lists
- correct ```ElementVisibilityTimeout``` error not being trapped correctly resulting in no info about missing fields on the ui

```*.features```
- youth court code tests
- *PROE* code regression test to ensure the matter type dropdown list is displaying the full text of the value (change made to support the youth court tests and the *PROE* screen shares the same underlying value set)
- changes to the tests which ref 'dulplicate' instead of duplicate
## Why make these changes?

Please describe why the changes were needed.
A new screen has been configured to support the youth court codes requiring new feature tests.

## Checklist

- [x] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-2908
