### PR TITLE
TA-2931 checkCaseStart refactoring - IMCA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Brewfile.lock.json
 features_report.html
 cucumber_web_report.html
+error_messages.csv

--- a/features/step_definitions/bulk_load_steps.rb
+++ b/features/step_definitions/bulk_load_steps.rb
@@ -214,7 +214,35 @@ Then(/problem outcomes should equal (\d*)/) do |num_of_problem_outcomes|
   @bulk_load_page = BulkLoadResultsPage.new
   @bulk_load_page.wait_until_summary_visible(wait: 60)
   expect(@bulk_load_page.summary).to have_problem_outcomes
-  expect(@bulk_load_page.summary.problem_outcomes.text).to eq(num_of_problem_outcomes)
+
+  actual_problem_outcomes = @bulk_load_page.summary.problem_outcomes.text.to_i
+  expected_problem_outcomes = num_of_problem_outcomes.to_i
+
+  if actual_problem_outcomes != expected_problem_outcomes
+    puts "Expected problem outcomes: #{expected_problem_outcomes}, but found: #{actual_problem_outcomes}"
+
+    # Capture and display the actual errors
+    error_table = @bulk_load_page.find('#BulkLoadErrorsVO table.x1h')
+    error_rows = error_table.all('tr')[1..-1] # Skip the header row
+
+    error_messages = error_rows.map do |row|
+      {
+        summary_id: row.find('td:nth-child(1)').text,
+        matter_type: row.find('td:nth-child(2)').text,
+        ufn: row.find('td:nth-child(3)').text,
+        client_surname: row.find('td:nth-child(4)').text,
+        error_type: row.find('td:nth-child(5)').text,
+        description: row.find('td:nth-child(6)').text
+      }
+    end
+
+    puts "Actual error messages displayed:"
+    error_messages.each_with_index do |error, index|
+      puts "#{index + 1}. Summary Id: #{error[:summary_id]}, Matter Type: #{error[:matter_type]}, UFN: #{error[:ufn]}, Client Surname: #{error[:client_surname]}, Error Type: #{error[:error_type]}, Description: #{error[:description]}"
+    end
+  end
+
+  expect(actual_problem_outcomes).to eq(expected_problem_outcomes)
 end
 
 

--- a/features/validations/legal_help/immigration_and_asylum/case_start_date_validation.feature
+++ b/features/validations/legal_help/immigration_and_asylum/case_start_date_validation.feature
@@ -27,7 +27,7 @@ Feature: validate case start date
       |     203 |              | IMLB:IOUT   | IE            |      30/09/2007 | PA00188          | AP00187      |
     Then the outcome does not save and gives an error containing:
       """
-      Case Start Date is before 01-Oct-2007
+      The reporting code combination that has been used is not valid. Please amend accordingly.
       """
 
   Scenario Outline: validate case start date for IMMIGRATION
@@ -36,7 +36,7 @@ Feature: validate case start date
       |     204 |              | IMCA:IOUT   | IE            |      30/09/2007 | PA00188          | AP00187      |
     Then the outcome does not save and gives an error containing:
       """
-      Case Start Date is before 01-Oct-2007
+      The reporting code combination that has been used is not valid. Please amend accordingly.
       """
 
   Scenario Outline: validate case start date for IMMIGRATION
@@ -45,7 +45,7 @@ Feature: validate case start date
       |     205 |              | IMCB:IOUT   | IE            |      30/09/2007 | PA00188          | AP00187      |
     Then the outcome does not save and gives an error containing:
       """
-      Case Start Date is before 01-Oct-2007
+      The reporting code combination that has been used is not valid. Please amend accordingly.
       """
 
   Scenario Outline: validate case start date for IMMIGRATION
@@ -54,7 +54,7 @@ Feature: validate case start date
       |     206 |              | IMXL:IOUT   | IE            |      30/09/2007 | PA00188          | AP00187      |
     Then the outcome does not save and gives an error containing:
       """
-      Case Start Date is before 01-Oct-2007
+      The reporting code combination that has been used is not valid. Please amend accordingly.
       """
 
   Scenario Outline: validate case start date for IMMIGRATION
@@ -63,7 +63,7 @@ Feature: validate case start date
       |     207 |              | IMXC:IOUT   | IE            |      30/09/2007 | PA00188          | AP00187      |
     Then the outcome does not save and gives an error containing:
       """
-      Case Start Date is before 01-Oct-2007
+      The reporting code combination that has been used is not valid. Please amend accordingly.
       """
 
   Scenario Outline: validate case start date for ASYLUM
@@ -78,7 +78,7 @@ Feature: validate case start date
       |     209 |              | IACA:IGOL   | IE            |      31/12/1994 | PA00188          | AP00187      | TR001                        |
     Then the outcome does not save and gives an error containing:
       """
-      Case Start Date is before 01-Jan-1995
+      The reporting code combination that has been used is not valid. Please amend accordingly.
       """
 
   Scenario Outline: validate case start date for IMMIGRATION
@@ -87,7 +87,7 @@ Feature: validate case start date
       |     210 |              | IMLB:IOUT   | IE            |      02/01/1995 | PA00188          | AP00187      |
     Then the outcome does not save and gives an error containing:
       """
-      Case Start Date is before 01-Oct-2007
+      The reporting code combination that has been used is not valid. Please amend accordingly.
       """
 
   Scenario Outline: validate case start date for IMMIGRATION
@@ -96,5 +96,5 @@ Feature: validate case start date
       |     211 |              | IMLB:IOUT   | IE            |      31/12/1994 | PA00188          | AP00187      |
     Then the outcome does not save and gives an error containing:
       """
-      Case Start Date is before 01-Oct-2007
+      The reporting code combination that has been used is not valid. Please amend accordingly.
       """

--- a/features/validations/legal_help/immigration_and_asylum/case_start_date_validation_bulkload_IMCA.feature
+++ b/features/validations/legal_help/immigration_and_asylum/case_start_date_validation_bulkload_IMCA.feature
@@ -1,0 +1,233 @@
+Feature: Validate case start date for IMCA
+
+  Scenario Outline: validate case start date for IMMIGRATION
+    Given a test firm user is logged in CWA
+    And user prepares to submit outcomes for test provider "LEGAL HELP.IMMAS#18"
+    Given the following Matter Types are chosen:
+      | IMCA:ICZN |
+      | IMCA:IEMP |
+      | IMCA:IEUL |
+      | IMCA:IFME |
+      | IMCA:IFVI |
+      | IMCA:IGOL |
+      | IMCA:IILL |
+    And the following outcomes are bulkloaded:
+      | #  | CLAIM_TYPE | CASE_START_DATE | OUTCOME_CODE | PROCUREMENT_AREA | ACCESS_POINT | IRC_SURGERY | STAGE_REACHED |
+      |  1 | CM         |        30/09/07 | IA           | PA00177          | AP00186      | N           | IG            |
+      |  2 | CM         |        30/09/07 | IB           | PA00177          | AP00186      | N           | IG            |
+      |  3 | CM         |        30/09/07 | IC           | PA00177          | AP00186      | N           | IG            |
+      |  4 | CM         |        30/09/07 | ID           | PA00177          | AP00186      | N           | IG            |
+      |  5 | CM         |        30/09/07 | IE           | PA00177          | AP00186      | N           | IG            |
+      |  6 | CM         |        30/09/07 | IF           | PA00177          | AP00186      | N           | IG            |
+      |  7 | CM         |        30/09/07 | IG           | PA00177          | AP00186      | N           | IG            |
+      |  8 | CM         |        30/09/07 | IU           | PA00177          | AP00186      | N           | IG            |
+      |  9 | CM         |        30/09/07 | IV           | PA00177          | AP00186      | N           | IG            |
+      | 10 | CM         |        30/09/07 | IW           | PA00177          | AP00186      | N           | IG            |
+      | 11 | CM         |        30/09/07 | IX           | PA00177          | AP00186      | N           | IG            |
+      | 12 | CM         |        30/09/07 | IY           | PA00177          | AP00186      | N           | IG            |
+      | 13 | CM         |        30/09/07 | IZ           | PA00177          | AP00186      | N           | IG            |
+    Then user should see the outcome results page
+    And problem outcomes should equal 91
+    And there should be no duplicate outcomes
+    And the following error message is expected for each:
+      | #  | ERROR_CODE_OR_MESSAGE      |
+      |  1 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  2 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  3 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  4 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  5 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  6 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  7 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  8 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  9 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 10 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 11 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 12 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 13 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 14 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 15 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 16 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 17 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 18 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 19 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 20 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 21 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 22 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 23 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 24 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 25 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 26 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 27 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 28 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 29 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 30 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 31 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 32 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 33 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 34 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 35 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 36 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 37 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 38 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 39 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 40 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 41 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 42 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 43 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 44 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 45 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 46 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 47 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 48 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 49 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 50 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 51 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 52 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 53 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 54 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 55 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 56 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 57 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 58 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 59 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 60 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 61 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 62 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 63 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 64 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 65 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 66 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 67 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 68 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 69 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 70 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 71 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 72 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 73 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 74 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 75 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 76 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 77 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 78 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 79 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 80 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 81 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 82 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 83 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 84 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 85 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 86 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 87 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 88 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 89 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 90 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 91 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+
+  Scenario Outline: validate case start date for IMMIGRATION
+    Given a test firm user is logged in CWA
+    And user prepares to submit outcomes for test provider "LEGAL HELP.IMMAS#18"
+    Given the following Matter Types are chosen:
+      | IMCA:IIRC |
+      | IMCA:IOTH |
+      | IMCA:IOUT |
+      | IMCA:IRVL |
+      | IMCA:ISTU |
+      | IMCA:ITWE |
+    And the following outcomes are bulkloaded:
+      | #  | CLAIM_TYPE | CASE_START_DATE | OUTCOME_CODE | PROCUREMENT_AREA | ACCESS_POINT | IRC_SURGERY | STAGE_REACHED |
+      |  1 | CM         |        30/09/07 | IA           | PA00177          | AP00186      | N           | IG            |
+      |  2 | CM         |        30/09/07 | IB           | PA00177          | AP00186      | N           | IG            |
+      |  3 | CM         |        30/09/07 | IC           | PA00177          | AP00186      | N           | IG            |
+      |  4 | CM         |        30/09/07 | ID           | PA00177          | AP00186      | N           | IG            |
+      |  5 | CM         |        30/09/07 | IE           | PA00177          | AP00186      | N           | IG            |
+      |  6 | CM         |        30/09/07 | IF           | PA00177          | AP00186      | N           | IG            |
+      |  7 | CM         |        30/09/07 | IG           | PA00177          | AP00186      | N           | IG            |
+      |  8 | CM         |        30/09/07 | IU           | PA00177          | AP00186      | N           | IG            |
+      |  9 | CM         |        30/09/07 | IV           | PA00177          | AP00186      | N           | IG            |
+      | 10 | CM         |        30/09/07 | IW           | PA00177          | AP00186      | N           | IG            |
+      | 11 | CM         |        30/09/07 | IX           | PA00177          | AP00186      | N           | IG            |
+      | 12 | CM         |        30/09/07 | IY           | PA00177          | AP00186      | N           | IG            |
+      | 13 | CM         |        30/09/07 | IZ           | PA00177          | AP00186      | N           | IG            |
+    Then user should see the outcome results page
+    And problem outcomes should equal 78
+    And there should be no duplicate outcomes
+    And the following error message is expected for each:
+      | #  | ERROR_CODE_OR_MESSAGE      |
+      |  1 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  2 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  3 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  4 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  5 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  6 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  7 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  8 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      |  9 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 10 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 11 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 12 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 13 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 14 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 15 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 16 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 17 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 18 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 19 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 20 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 21 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 22 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 23 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 24 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 25 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 26 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 27 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 28 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 29 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 30 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 31 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 32 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 33 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 34 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 35 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 36 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 37 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 38 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 39 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 40 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 41 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 42 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 43 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 44 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 45 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 46 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 47 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 48 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 49 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 50 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 51 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 52 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 53 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 54 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 55 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 56 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 57 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 58 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 59 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 60 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 61 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 62 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 63 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 64 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 65 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 66 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 67 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 68 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 69 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 70 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 71 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 72 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 73 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 74 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 75 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 76 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 77 | XXLSC_AM_PRE_LAR2_COMB_MSG |
+      | 78 | XXLSC_AM_PRE_LAR2_COMB_MSG |     

--- a/features/validations/legal_help/immigration_and_asylum/case_start_date_validation_manual_IMCA.feature
+++ b/features/validations/legal_help/immigration_and_asylum/case_start_date_validation_manual_IMCA.feature
@@ -1,0 +1,22 @@
+Feature: Validate case start date for IMCA
+
+  Background:
+    Given user is on their "LEGAL HELP" submission details page
+
+  Scenario Outline: IMCA outcomes are not valid with a CSD < 01-OCT-2007
+    When user adds outcomes for "Legal Help" "Immigration" with fields like this:
+      | case_id | schedule_ref | case_start_date | matter_type | outcome_code | procurement_area | access_point | claim_type | stage_reached | irc_surgery |
+      |     101 |              |      30/09/2007 | IMCA:IFME   | IU           | PA00177          | AP00186      | CM         | IG            | N           |
+    Then the outcome does not save and gives an error containing:
+      """
+      The reporting code combination that has been used is not valid. Please amend accordingly.
+      """
+
+  Scenario Outline: IMCA outcomes are not valid with a CSD < 01-OCT-2007
+    When user adds outcomes for "Legal Help" "Immigration" with fields like this:
+      | case_id | schedule_ref | case_start_date | matter_type | outcome_code | procurement_area | access_point | claim_type | stage_reached | irc_surgery |
+       |     102 |              |      30/09/2007 | IMCA:IOTH   | IF           | PA00177          | AP00186      | CM         | IG            | N           |
+    Then the outcome does not save and gives an error containing:
+      """
+      The reporting code combination that has been used is not valid. Please amend accordingly.
+      """


### PR DESCRIPTION
## What does this pull request do?

Please describe what you did.
Created and modified tests to ensure that IMCA MT1 outcomes are flagged as invalid with the correct error message in line with refactoring work when the outcomes are submitted either through the manual process or bulkload.

Modified step defs:
```cwa_outcome_steps.rb```
- If the expected error has not appeared then the step def will fail and report back the actual errors.
- If the expected error has appeared but there have been others, then the step def will pass and the extra errors are displayed.

```bulk_load_steps.rb```
- If the expected error has not appeared then the step def will fail and report back the actual errors.

These changes are to assist the workflow of the tester when troubleshooting what can be hard to fathom errors in CWA outcome validation.

## Why make these changes?

Please describe why the changes were needed.
Refactoring work is moving validation within CWA and features tests are needed to support this.

## Checklist

- [x] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-2931
