### PR TITLE
Remove redundant workflow filters from CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,6 @@ workflows:
       - Notify_Slack_For_Approval:
           requires:
             - Build_and_Push_Docker_Image
-    when: on_success
 
   deploy_tests:
     jobs:
@@ -146,7 +145,6 @@ workflows:
       - Notify_Slack_For_Success:
           requires:
             - Deploy_tests_on_cloud_platform
-    when: on_success
     triggers:
       - schedule:
           cron: "30 1 * * *"


### PR DESCRIPTION
## What does this pull request do?:

In CircleCI workflow config the `when` filter is used to control if a
workflow should be run in a pipeline or not. The default behaviour when
a `when` filter is not present is to always run the workflow.

The value for a workflow `when` filter should be a "logic statement"[1]
and if that statement evaluates to a truthy value then the workflow is
run.

The current logic statements are interpreted with a JavaScript-like
truthiness, particularly, a non-empty string is considered truthy.

There are no special constants in workflow `when` filters (unlike the
`when` attribute on a step), so a non-empty string constant is treated
as a truthy value, whatever the actual string contents.

In other words, `when: on_success` (YAML parses `on_success` as a
string) is equivalent to `when: true` (YAML parses `true` as a boolean),
which is equivalent to the default behaviour.

[1] https://circleci.com/docs/configuration-reference/#logic-statements

## Why make these changes?
CircleCI will be adding stricter validation of `when` filters in workflows
which may lead to config failures[2]

[2] https://circleci.com/changelog/dynamic-when-statements-breaking-change/