### PR TITLE
Reduce test time

### DIFF
--- a/features/pages/outcome_page.rb
+++ b/features/pages/outcome_page.rb
@@ -13,7 +13,7 @@ module OutcomePage
     )
     page = SubmissionDetailsPage.new
     return if page.has_no_select_all_link?(wait: 0)
-    page.select_all
+    page.select_all_link.click
     page.delete_button.click
     page.confirm_delete_button.click
   end

--- a/features/step_definitions/bulk_load_steps.rb
+++ b/features/step_definitions/bulk_load_steps.rb
@@ -25,7 +25,7 @@ Given( /^user prepares to submit outcomes for test provider "(.*)"(\s+again)?$/)
       submission_details_page = SubmissionDetailsPage.new
       if !submission_details_page.has_text?(/No results found/)
         STDOUT.print 'Cleaning existing outcomes for test reference...'
-        submission_details_page.select_all
+        submission_details_page.select_all_link.click
         submission_details_page.delete_button.click
         submission_details_page.confirm_delete_button.click
         STDOUT.puts ' done.'

--- a/features/step_definitions/cwa_outcome_steps.rb
+++ b/features/step_definitions/cwa_outcome_steps.rb
@@ -166,11 +166,14 @@ Then("the outcome does not save and gives an error containing:") do |expected_me
   # Collect all errors from the table
   all_errors = error_table.all('ol.x3z li, div.x3z').map(&:text)
 
+  # Convert all_errors to a set for faster lookup
+  all_errors_set = all_errors.to_set
+
   # Split the expected error into individual lines for comparison
   expected_errors = expected_message.strip.split("\n").map(&:strip)
 
   # Check if all expected errors are present in the actual errors
-  missing_errors = expected_errors.reject { |error| all_errors.any? { |actual| actual.include?(error) } }
+  missing_errors = expected_errors.reject { |error| all_errors_set.any? { |actual| actual.include?(error) } }
 
   if missing_errors.empty?
     puts "All expected error messages were found."

--- a/features/step_definitions/pricing_outcome_steps.rb
+++ b/features/step_definitions/pricing_outcome_steps.rb
@@ -36,7 +36,7 @@ Given('user deleted any existing {string} outcomes for the test firm') do |categ
   if !@submission_details_page.has_text?(/No results found/)
     STDOUT.print 'Cleaning existing outcomes for test reference...'
 
-    @submission_details_page.select_all.click
+    @submission_details_page.select_all_link.click
     @submission_details_page.delete_button.click
     @submission_details_page.confirm_delete_button.click
 

--- a/features/support/ui/submission_details_page.rb
+++ b/features/support/ui/submission_details_page.rb
@@ -13,7 +13,7 @@ class SubmissionDetailsPage < SitePrism::Page
   set_url '/OA_HTML/OA.jsp?page=/xxlsc/oracle/apps/xxlsc/am/webui/SubmissionListPG&*'
 
   sections :outcomes, SubmissionDetailsOutcomeSection, :xpath, '//*[@id="SubmissionTable"]/table[2]/tbody/tr[1]/following-sibling::tr[position() > 0]'
-  element :select_all_link, :xpath, '//*[@id="SubmissionTable"]/table[1]/tbody/tr[3]/td/table/tbody/tr/td/a[1]'
+  element :select_all_link, 'a[href*="tableSelectAll"]'
   element :delete_button, :xpath, '//*[@id="Delete"]'
   element :confirm_delete_button, :xpath, '//*[@id="Yes"]'
   element :return_to_submission_list, :xpath, '//*[@id="ReturnToSubmissionList"]'

--- a/features/validations/legal_help/immigration_and_asylum/prior_authority_number.feature
+++ b/features/validations/legal_help/immigration_and_asylum/prior_authority_number.feature
@@ -56,10 +56,9 @@ Feature: Validation for Prior authority number
       | 1 |     001 | 010523/001 | CM         | IA           |      01/05/2023 |          30/05/2023 |           0 |            0 | N             |            0 |                 1000 |                 0 | a000000             |
     Then user should see the outcome results page
     And problem outcomes should equal 1
-    Then the outcome does not save and gives an error containing:
-      """
-      The Prior Authority Reference number entered is incorrect. Please check again and enter the correct reference number.
-      """
+    Then the following results are expected:
+      | # | ERROR_CODE_OR_MESSAGE                                                                                                 |
+      | 1 | The Prior Authority Reference number entered is incorrect. Please check again and enter the correct reference number. |
 
   @delete_outcome_after @manual_submission
   Scenario Outline: Manual submission PAN validation
@@ -83,10 +82,10 @@ Feature: Validation for Prior authority number
       The Prior Authority Reference number entered is incorrect. Please check again and enter the correct reference number.
       """
 
-   @delete_outcome_after @manual_submission
-   Scenario Outline: Manual submission PAN validation
+  @delete_outcome_after @manual_submission
+  Scenario Outline: Manual submission PAN validation
     Given user is on their "LEGAL HELP" submission details page
     When user adds outcomes for "Legal Help" "Immigration And Asylum" with fields like this:
       | case_id | matter_type | case_start_date | outcome_code | procurement_area | access_point | exemption_criteria_satisfied | work_concluded_date | prior_authority_ref |
-      |     001 | IAXL:IDIF   |        25/04/22 | --           | PA00137          | AP00153      | TR001                        |            26/04/22 | A000000              |
+      |     001 | IAXL:IDIF   |        25/04/22 | --           | PA00137          | AP00153      | TR001                        |            26/04/22 | A000000             |
     Then user should see the outcome results page


### PR DESCRIPTION
## What does this pull request do?
To modify the step to delete outcomes at once

## Why make these changes?

to reduce test time

## Checklist

It's not related to any ticket. But after youth court tests, the pack takes more time to finish and circle ci ending the job without completion. 