### PR TITLE
Fix dates youth court

### DIFF
--- a/features/pricing/crime_lower/criminal_proceedings/youth_court/youe_pricing.feature
+++ b/features/pricing/crime_lower/criminal_proceedings/youth_court/youe_pricing.feature
@@ -8,18 +8,18 @@ Feature: YOUE code Manual and Bulk load pricing
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      182.01 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      919.96 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      321.37 |
+      | 1 | 061224/001 |      06/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      822.47 |
+      | 2 | 061224/002 |      06/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      182.01 |
+      | 3 | 061224/003 |      06/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      919.96 |
+      | 4 | 061224/004 |      06/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      321.37 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value    | Comment                                   |
-      | 1 | 010924/001 | £ 822.47 | Standard fee for category 1A YOUE £822.47 |
-      | 2 | 010924/002 | £ 182.01 | Standard fee for category 1B YOUE £182.01 |
-      | 3 | 010924/003 | £ 919.96 | Standard fee for category 2A YOUE £919.96 |
-      | 4 | 010924/004 | £ 321.37 | Standard fee for category 2B YOUE £321.37 |
+      | 1 | 061224/001 | £ 822.47 | Standard fee for category 1A YOUE £822.47 |
+      | 2 | 061224/002 | £ 182.01 | Standard fee for category 1B YOUE £182.01 |
+      | 3 | 061224/003 | £ 919.96 | Standard fee for category 2A YOUE £919.96 |
+      | 4 | 061224/004 | £ 321.37 | Standard fee for category 2B YOUE £321.37 |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUE pricing check for YOUE with vat
@@ -29,18 +29,18 @@ Feature: YOUE code Manual and Bulk load pricing
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 | Y             |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      182.01 | Y             |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      919.96 | Y             |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      321.37 | Y             |
+      | 1 | 061224/001 |      06/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      822.47 | Y             |
+      | 2 | 061224/002 |      06/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      182.01 | Y             |
+      | 3 | 061224/003 |      06/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      919.96 | Y             |
+      | 4 | 061224/004 |      06/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      321.37 | Y             |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                             |
-      | 1 | 010924/001 | £ 986.96   | Standard fee for category 1A YOUE £822.47 + vat 20% |
-      | 2 | 010924/002 | £ 218.41   | Standard fee for category 1B YOUE £182.01 + vat 20% |
-      | 3 | 010924/003 | £ 1,103.95 | Standard fee for category 2A YOUE £919.96 + vat 20% |
-      | 4 | 010924/004 | £ 385.64   | Standard fee for category 2B YOUE £321.37 + vat 20% |
+      | 1 | 061224/001 | £ 986.96   | Standard fee for category 1A YOUE £822.47 + vat 20% |
+      | 2 | 061224/002 | £ 218.41   | Standard fee for category 1B YOUE £182.01 + vat 20% |
+      | 3 | 061224/003 | £ 1,103.95 | Standard fee for category 2A YOUE £919.96 + vat 20% |
+      | 4 | 061224/004 | £ 385.64   | Standard fee for category 2B YOUE £321.37 + vat 20% |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUE pricing check for YOUE with vat and travel and waiting costs
@@ -50,18 +50,18 @@ Feature: YOUE code Manual and Bulk load pricing
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS |
-      | 1 | 301223/001 |     30/12/2023 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 | Y             |          100 |                  100 |
-      | 2 | 301223/002 |     30/12/2023 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      182.01 | Y             |          100 |                  100 |
-      | 3 | 301223/003 |     30/12/2023 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      919.96 | Y             |          100 |                  100 |
-      | 4 | 301223/004 |     30/12/2023 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      321.37 | Y             |          100 |                  100 |
+      | 1 | 051224/001 |     05/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      822.47 | Y             |          100 |                  100 |
+      | 2 | 051224/002 |     05/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      182.01 | Y             |          100 |                  100 |
+      | 3 | 051224/003 |     05/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      919.96 | Y             |          100 |                  100 |
+      | 4 | 051224/004 |     05/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      321.37 | Y             |          100 |                  100 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                         |
-      | 1 | 301223/001 | £ 1,226.96 | Standard fee for category 1A YOUE + travel costs + waiting costs + 20% vat on total =  £1226.96 |
-      | 2 | 301223/002 | £ 458.41   | Standard fee for category 1B YOUE + travel costs + waiting costs + 20% vat on total = £458.41   |
-      | 3 | 301223/003 | £ 1,343.95 | Standard fee for category 2A YOUE + travel costs + waiting costs + 20% vat on total =  £1343.95 |
-      | 4 | 301223/004 | £ 625.64   | Standard fee for category 2B YOUE + travel costs + waiting costs + 20% vat on total =  £625.64  |
+      | 1 | 051224/001 | £ 1,226.96 | Standard fee for category 1A YOUE + travel costs + waiting costs + 20% vat on total =  £1226.96 |
+      | 2 | 051224/002 | £ 458.41   | Standard fee for category 1B YOUE + travel costs + waiting costs + 20% vat on total = £458.41   |
+      | 3 | 051224/003 | £ 1,343.95 | Standard fee for category 2A YOUE + travel costs + waiting costs + 20% vat on total =  £1343.95 |
+      | 4 | 051224/004 | £ 625.64   | Standard fee for category 2B YOUE + travel costs + waiting costs + 20% vat on total =  £625.64  |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUE pricing check for YOUE with vat and travel and waiting costs with disbursement and disbursement vat
@@ -71,18 +71,18 @@ Feature: YOUE code Manual and Bulk load pricing
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 | Y             |          100 |                  100 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      182.01 | Y             |          100 |                  100 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      919.96 | Y             |          100 |                  100 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      321.37 | Y             |          100 |                  100 |                  100 |                20 |
+      | 1 | 061224/001 |      06/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      822.47 | Y             |          100 |                  100 |                  100 |                20 |
+      | 2 | 061224/002 |      06/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      182.01 | Y             |          100 |                  100 |                  100 |                20 |
+      | 3 | 061224/003 |      06/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      919.96 | Y             |          100 |                  100 |                  100 |                20 |
+      | 4 | 061224/004 |      06/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      321.37 | Y             |          100 |                  100 |                  100 |                20 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                                           |
-      | 1 | 010924/001 | £ 1,346.96 | Standard fee for category 1A YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1346.96 |
-      | 2 | 010924/002 | £ 578.41   | Standard fee for category 1B YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat = £578.41   |
-      | 3 | 010924/003 | £ 1,463.95 | Standard fee for category 2A YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1463.95 |
-      | 4 | 010924/004 | £ 745.64   | Standard fee for category 2B YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £745.64  |
+      | 1 | 061224/001 | £ 1,346.96 | Standard fee for category 1A YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1346.96 |
+      | 2 | 061224/002 | £ 578.41   | Standard fee for category 1B YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat = £578.41   |
+      | 3 | 061224/003 | £ 1,463.95 | Standard fee for category 2A YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1463.95 |
+      | 4 | 061224/004 | £ 745.64   | Standard fee for category 2B YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £745.64  |
 
   Scenario: bulkload Crime Lower stage reached code YOUE pricing check for YOUE with vat and  without travel and waiting costs with disbursement and disbursement vat
     Given a test firm user is logged in CWA
@@ -91,31 +91,31 @@ Feature: YOUE code Manual and Bulk load pricing
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 | Y             |            0 |                    0 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      182.01 | Y             |            0 |                    0 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      919.96 | Y             |            0 |                    0 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      321.37 | Y             |            0 |                    0 |                  100 |                20 |
+      | 1 | 061224/001 |      06/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      822.47 | Y             |            0 |                    0 |                  100 |                20 |
+      | 2 | 061224/002 |      06/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      182.01 | Y             |            0 |                    0 |                  100 |                20 |
+      | 3 | 061224/003 |      06/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      919.96 | Y             |            0 |                    0 |                  100 |                20 |
+      | 4 | 061224/004 |      06/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      321.37 | Y             |            0 |                    0 |                  100 |                20 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                                           |
-      | 1 | 010924/001 | £ 1,106.96 | Standard fee for category 1A YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1106.96 |
-      | 2 | 010924/002 | £ 338.41   | Standard fee for category 1B YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat = £338.41   |
-      | 3 | 010924/003 | £ 1,223.95 | Standard fee for category 2A YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1223.95 |
-      | 4 | 010924/004 | £ 505.64   | Standard fee for category 2B YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £505.64  |
+      | 1 | 061224/001 | £ 1,106.96 | Standard fee for category 1A YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1106.96 |
+      | 2 | 061224/002 | £ 338.41   | Standard fee for category 1B YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat = £338.41   |
+      | 3 | 061224/003 | £ 1,223.95 | Standard fee for category 2A YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1223.95 |
+      | 4 | 061224/004 | £ 505.64   | Standard fee for category 2B YOUE + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £505.64  |
 
   @delete_outcome_after @manual_submission
   Scenario Outline: Pricing tests manual entry for YOUE
     Given user is on their "Crime Lower" submission details page
     When user adds outcomes for "Crime Lower" "Criminal Proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id |
-      | YOUE        |      01/9/2024 |               1A |      822.47 | 010924/001 |         01-SEP-2024 | C1013          |       1 |
-      | YOUE        |      01/9/2024 |               1B |      182.01 | 010924/002 |         01-SEP-2024 | C1013          |       1 |
-      | YOUE        |      01/9/2024 |               2A |      919.96 | 010924/003 |         01-SEP-2024 | C1013          |       1 |
-      | YOUE        |      01/9/2024 |               2B |      321.37 | 010924/004 |         01-SEP-2024 | C1013          |       1 |
+      | YOUE        |      06/12/2024 |               1A |      822.47 | 061224/001 |         06-DEC-2024 | C1013          |       1 |
+      | YOUE        |      06/12/2024 |               1B |      182.01 | 061224/002 |         06-DEC-2024 | C1013          |       1 |
+      | YOUE        |      06/12/2024 |               2A |      919.96 | 061224/003 |         06-DEC-2024 | C1013          |       1 |
+      | YOUE        |      06/12/2024 |               2B |      321.37 | 061224/004 |         06-DEC-2024 | C1013          |       1 |
     Then user should see the following outcomes:
       | # | UFN        | Value    | Comment                                 |
-      | 1 | 010924/001 | £ 822.47 | Priced at Fixed fee for YOUE at £822.47 |
-      | 1 | 010924/002 | £ 182.01 | Priced at Fixed fee for YOUE at £182.01 |
-      | 1 | 010924/003 | £ 919.96 | Priced at Fixed fee for YOUE at £919.96 |
-      | 1 | 010924/004 | £ 321.37 | Priced at Fixed fee for YOUE at £321.37 |
+      | 1 | 061224/001 | £ 822.47 | Priced at Fixed fee for YOUE at £822.47 |
+      | 1 | 061224/002 | £ 182.01 | Priced at Fixed fee for YOUE at £182.01 |
+      | 1 | 061224/003 | £ 919.96 | Priced at Fixed fee for YOUE at £919.96 |
+      | 1 | 061224/004 | £ 321.37 | Priced at Fixed fee for YOUE at £321.37 |

--- a/features/pricing/crime_lower/criminal_proceedings/youth_court/youe_pricing.feature
+++ b/features/pricing/crime_lower/criminal_proceedings/youth_court/youe_pricing.feature
@@ -50,10 +50,10 @@ Feature: YOUE code Manual and Bulk load pricing
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS |
-      | 1 | 051224/001 |     05/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      822.47 | Y             |          100 |                  100 |
-      | 2 | 051224/002 |     05/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      182.01 | Y             |          100 |                  100 |
-      | 3 | 051224/003 |     05/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      919.96 | Y             |          100 |                  100 |
-      | 4 | 051224/004 |     05/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      321.37 | Y             |          100 |                  100 |
+      | 1 | 051224/001 |     06/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      822.47 | Y             |          100 |                  100 |
+      | 2 | 051224/002 |     06/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      182.01 | Y             |          100 |                  100 |
+      | 3 | 051224/003 |     06/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      919.96 | Y             |          100 |                  100 |
+      | 4 | 051224/004 |     06/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      321.37 | Y             |          100 |                  100 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:

--- a/features/pricing/crime_lower/criminal_proceedings/youth_court/youf_pricing.feature
+++ b/features/pricing/crime_lower/criminal_proceedings/youth_court/youf_pricing.feature
@@ -8,18 +8,18 @@ Feature: YOUF code Bulk load pricing
       | YOUF |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      437.81 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1335.67 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      737.08 |
+      | 1 |061224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |     1072.74 |
+      | 2 |061224/002 |     06/12/2024 |               1B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      437.81 |
+      | 3 |061224/003 |     06/12/2024 |               2A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |     1335.67 |
+      | 4 |061224/004 |     06/12/2024 |               2B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      737.08 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                    |
-      | 1 | 010924/001 | £ 1,072.74 | Standard fee for category 1A YOUF £1072.74 |
-      | 2 | 010924/002 | £ 437.81   | Standard fee for category 1B YOUF £437.81  |
-      | 3 | 010924/003 | £ 1,335.67 | Standard fee for category 2A YOUF £1335.67 |
-      | 4 | 010924/004 | £ 737.08   | Standard fee for category 2B YOUF £737.08  |
+      | 1 |061224/001 | £ 1,072.74 | Standard fee for category 1A YOUF £1072.74 |
+      | 2 |061224/002 | £ 437.81   | Standard fee for category 1B YOUF £437.81  |
+      | 3 |061224/003 | £ 1,335.67 | Standard fee for category 2A YOUF £1335.67 |
+      | 4 |061224/004 | £ 737.08   | Standard fee for category 2B YOUF £737.08  |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUF pricing check for YOUF with vat and travel and waiting costs with disbursement and disbursement vat
@@ -29,15 +29,15 @@ Feature: YOUF code Bulk load pricing
       | YOUF |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 | Y             |          100 |                  100 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      437.81 | Y             |          100 |                  100 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1335.67 | Y             |          100 |                  100 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      737.08 | Y             |          100 |                  100 |                  100 |                20 |
+      | 1 |061224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |     1072.74 | Y             |          100 |                  100 |                  100 |                20 |
+      | 2 |061224/002 |     06/12/2024 |               1B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      437.81 | Y             |          100 |                  100 |                  100 |                20 |
+      | 3 |061224/003 |     06/12/2024 |               2A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |     1335.67 | Y             |          100 |                  100 |                  100 |                20 |
+      | 4 |061224/004 |     06/12/2024 |               2B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      737.08 | Y             |          100 |                  100 |                  100 |                20 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                                            |
-      | 1 | 010924/001 | £ 1,647.29 | Standard fee for category 1A YOUF + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1,647.29 |
-      | 2 | 010924/002 | £ 885.37   | Standard fee for category 1B YOUF + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat = £885.37    |
-      | 3 | 010924/003 | £ 1,962.80 | Standard fee for category 2A YOUF + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1,962.80 |
-      | 4 | 010924/004 | £ 1,244.50 | Standard fee for category 2B YOUF + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1,244.50 |
+      | 1 |061224/001 | £ 1,647.29 | Standard fee for category 1A YOUF + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1,647.29 |
+      | 2 |061224/002 | £ 885.37   | Standard fee for category 1B YOUF + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat = £885.37    |
+      | 3 |061224/003 | £ 1,962.80 | Standard fee for category 2A YOUF + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1,962.80 |
+      | 4 |061224/004 | £ 1,244.50 | Standard fee for category 2B YOUF + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1,244.50 |

--- a/features/pricing/crime_lower/criminal_proceedings/youth_court/youk_pricing.feature
+++ b/features/pricing/crime_lower/criminal_proceedings/youth_court/youk_pricing.feature
@@ -8,18 +8,18 @@ Feature: YOUK code Bulk load pricing
       | YOUK |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      884.61 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      232.53 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      995.73 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      397.14 |
+      | 1 | 061224/001 |      06/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      884.61 |
+      | 2 | 061224/002 |      06/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      232.53 |
+      | 3 | 061224/003 |      06/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      995.73 |
+      | 4 | 061224/004 |      06/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      397.14 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value    | Comment                                   |
-      | 1 | 010924/001 | £ 884.61 | Standard fee for category 1A YOUK £884.61 |
-      | 2 | 010924/002 | £ 232.53 | Standard fee for category 1B YOUK £232.53 |
-      | 3 | 010924/003 | £ 995.73 | Standard fee for category 2A YOUK £995.73 |
-      | 4 | 010924/004 | £ 397.14 | Standard fee for category 2B YOUK £397.14 |
+      | 1 | 061224/001 | £ 884.61 | Standard fee for category 1A YOUK £884.61 |
+      | 2 | 061224/002 | £ 232.53 | Standard fee for category 1B YOUK £232.53 |
+      | 3 | 061224/003 | £ 995.73 | Standard fee for category 2A YOUK £995.73 |
+      | 4 | 061224/004 | £ 397.14 | Standard fee for category 2B YOUK £397.14 |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUK pricing check for YOUK with vat and travel and waiting costs with disbursement and disbursement vat
@@ -29,15 +29,15 @@ Feature: YOUK code Bulk load pricing
       | YOUK |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      884.61 | Y             |          100 |                  100 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      232.53 | Y             |          100 |                  100 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      995.73 | Y             |          100 |                  100 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      397.14 | Y             |          100 |                  100 |                  100 |                20 |
+      | 1 | 061224/001 |      06/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      884.61 | Y             |          100 |                  100 |                  100 |                20 |
+      | 2 | 061224/002 |      06/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      232.53 | Y             |          100 |                  100 |                  100 |                20 |
+      | 3 | 061224/003 |      06/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      995.73 | Y             |          100 |                  100 |                  100 |                20 |
+      | 4 | 061224/004 |      06/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      397.14 | Y             |          100 |                  100 |                  100 |                20 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                                                      |
-      | 1 | 010924/001 | £ 1,181.53 | Standard fee for category 1A YOUK + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,181.53 |
-      | 2 | 010924/002 | £ 399.04   | Standard fee for category 1B YOUK + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat = £399.04    |
-      | 3 | 010924/003 | £ 1,314.88 | Standard fee for category 2A YOUK + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,314.88 |
-      | 4 | 010924/004 | £ 596.57   | Standard fee for category 2B YOUK + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £596.57   |
+      | 1 | 061224/001 | £ 1,181.53 | Standard fee for category 1A YOUK + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,181.53 |
+      | 2 | 061224/002 | £ 399.04   | Standard fee for category 1B YOUK + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat = £399.04    |
+      | 3 | 061224/003 | £ 1,314.88 | Standard fee for category 2A YOUK + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,314.88 |
+      | 4 | 061224/004 | £ 596.57   | Standard fee for category 2B YOUK + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £596.57   |

--- a/features/pricing/crime_lower/criminal_proceedings/youth_court/youl_pricing.feature
+++ b/features/pricing/crime_lower/criminal_proceedings/youth_court/youl_pricing.feature
@@ -8,18 +8,18 @@ Feature: YOUL code Bulk load pricing
       | YOUL |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      500.99 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1430.44 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      831.85 |
+      | 1 | 061224/001 |      06/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 |
+      | 2 | 061224/002 |      06/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      500.99 |
+      | 3 | 061224/003 |      06/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |     1430.44 |
+      | 4 | 061224/004 |      06/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      831.85 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                    |
-      | 1 | 010924/001 | £ 1,141.17 | Standard fee for category 1A YOUL £1141.17 |
-      | 2 | 010924/002 | £ 500.99   | Standard fee for category 1B YOUL £500.99  |
-      | 3 | 010924/003 | £ 1,430.44 | Standard fee for category 2A YOUL £1430.44 |
-      | 4 | 010924/004 | £ 831.85   | Standard fee for category 2B YOUL £831.85  |
+      | 1 | 061224/001 | £ 1,141.17 | Standard fee for category 1A YOUL £1141.17 |
+      | 2 | 061224/002 | £ 500.99   | Standard fee for category 1B YOUL £500.99  |
+      | 3 | 061224/003 | £ 1,430.44 | Standard fee for category 2A YOUL £1430.44 |
+      | 4 | 061224/004 | £ 831.85   | Standard fee for category 2B YOUL £831.85  |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOULL pricing check for YOUL with vat and travel and waiting costs with disbursement and disbursement vat
@@ -29,15 +29,15 @@ Feature: YOUL code Bulk load pricing
       | YOUL |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |          100 |                  100 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      500.99 | Y             |          100 |                  100 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1430.44 | Y             |          100 |                  100 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      831.85 | Y             |          100 |                  100 |                  100 |                20 |
+      | 1 | 061224/001 |      06/12/2024 |               1A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |          100 |                  100 |                  100 |                20 |
+      | 2 | 061224/002 |      06/12/2024 |               1B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      500.99 | Y             |          100 |                  100 |                  100 |                20 |
+      | 3 | 061224/003 |      06/12/2024 |               2A | CP18         |           06/12/2024 | Y           | C1013          |                        1 |     1430.44 | Y             |          100 |                  100 |                  100 |                20 |
+      | 4 | 061224/004 |      06/12/2024 |               2B | CP18         |           06/12/2024 | Y           | C1013          |                        1 |      831.85 | Y             |          100 |                  100 |                  100 |                20 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                                                      |
-      | 1 | 010924/001 | £ 1,489.40 | Standard fee for category 1A YOUL + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,489.40 |
-      | 2 | 010924/002 | £ 721.19   | Standard fee for category 1B YOUL + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat = £721.19    |
-      | 3 | 010924/003 | £ 1,836.53 | Standard fee for category 2A YOUL + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,836.53 |
-      | 4 | 010924/004 | £ 1,118.22 | Standard fee for category 2B YOUL + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,118.22 |
+      | 1 | 061224/001 | £ 1,489.40 | Standard fee for category 1A YOUL + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,489.40 |
+      | 2 | 061224/002 | £ 721.19   | Standard fee for category 1B YOUL + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat = £721.19    |
+      | 3 | 061224/003 | £ 1,836.53 | Standard fee for category 2A YOUL + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,836.53 |
+      | 4 | 061224/004 | £ 1,118.22 | Standard fee for category 2B YOUL + ignore (travel costs +  waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,118.22 |

--- a/features/pricing/crime_lower/criminal_proceedings/youth_court/youx_pricing.feature
+++ b/features/pricing/crime_lower/criminal_proceedings/youth_court/youx_pricing.feature
@@ -8,18 +8,18 @@ Feature: YOUX code Manual and Bulk load pricing
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 |
-      | 2 | 010924/002 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      822.47 |
-      | 3 | 010924/003 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      437.81 |
-      | 4 | 010924/004 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      182.01 |
+      | 1 | 061224/001 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 |
+      | 2 | 061224/002 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      822.47 |
+      | 3 | 061224/003 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      437.81 |
+      | 4 | 061224/004 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      182.01 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                        |
-      | 1 | 010924/001 | £ 1,072.74 | Standard fee for category 1A-HSF YOUX £1072.74 |
-      | 2 | 010924/002 | £ 822.47   | Standard fee for category 1A-LSF YOUX £822.47  |
-      | 3 | 010924/003 | £ 437.81   | Standard fee for category 1B-HSF YOUX £437.81  |
-      | 4 | 010924/004 | £ 182.01   | Standard fee for category 1B-LSF YOUX £182.01  |
+      | 1 | 061224/001 | £ 1,072.74 | Standard fee for category 1A-HSF YOUX £1072.74 |
+      | 2 | 061224/002 | £ 822.47   | Standard fee for category 1A-LSF YOUX £822.47  |
+      | 3 | 061224/003 | £ 437.81   | Standard fee for category 1B-HSF YOUX £437.81  |
+      | 4 | 061224/004 | £ 182.01   | Standard fee for category 1B-LSF YOUX £182.01  |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUX pricing check for YOUX with vat
@@ -29,18 +29,18 @@ Feature: YOUX code Manual and Bulk load pricing
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR |
-      | 1 | 010924/001 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 | Y             |
-      | 2 | 010924/002 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      822.47 | Y             |
-      | 3 | 010924/003 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      437.81 | Y             |
-      | 4 | 010924/004 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      182.01 | Y             |
+      | 1 | 061224/001 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 | Y             |
+      | 2 | 061224/002 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      822.47 | Y             |
+      | 3 | 061224/003 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      437.81 | Y             |
+      | 4 | 061224/004 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      182.01 | Y             |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                   |
-      | 1 | 010924/001 | £ 1,287.29 | Standard fee for category 1A-HSF YOUX £1072.74  + vat 20% |
-      | 2 | 010924/002 | £ 986.96   | Standard fee for category 1A-LSF YOUX £822.47  + vat 20%  |
-      | 3 | 010924/003 | £ 525.37   | Standard fee for category 1B-HSF YOUX £437.81  + vat 20%  |
-      | 4 | 010924/004 | £ 218.41   | Standard fee for category 1B-LSF YOUX £182.01  + vat 20%  |
+      | 1 | 061224/001 | £ 1,287.29 | Standard fee for category 1A-HSF YOUX £1072.74  + vat 20% |
+      | 2 | 061224/002 | £ 986.96   | Standard fee for category 1A-LSF YOUX £822.47  + vat 20%  |
+      | 3 | 061224/003 | £ 525.37   | Standard fee for category 1B-HSF YOUX £437.81  + vat 20%  |
+      | 4 | 061224/004 | £ 218.41   | Standard fee for category 1B-LSF YOUX £182.01  + vat 20%  |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUX pricing check for YOUX with vat and travel and waiting costs with vat
@@ -50,18 +50,18 @@ Feature: YOUX code Manual and Bulk load pricing
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS |
-      | 1 | 010924/001 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 | Y             |          100 |                  100 |
-      | 2 | 010924/002 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      822.47 | Y             |          100 |                  100 |
-      | 3 | 010924/003 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      437.81 | Y             |          100 |                  100 |
-      | 4 | 010924/004 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      182.01 | Y             |          100 |                  100 |
+      | 1 | 061224/001 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 | Y             |          100 |                  100 |
+      | 2 | 061224/002 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      822.47 | Y             |          100 |                  100 |
+      | 3 | 061224/003 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      437.81 | Y             |          100 |                  100 |
+      | 4 | 061224/004 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      182.01 | Y             |          100 |                  100 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                       |
-      | 1 | 010924/001 | £ 1,527.29 | Standard fee for category 1A-HSF YOUX £1072.74 + travel costs + waiting costs + 20% vat on total =  £1,527.29 |
-      | 2 | 010924/002 | £ 1,226.96 | Standard fee for category 1A-LSF YOUX £822.47 + travel costs + waiting costs + 20% vat on total = £ 1,226.96  |
-      | 3 | 010924/003 | £ 765.37   | Standard fee for category 1B-HSF YOUX £437.81 + travel costs + waiting costs + 20% vat on total =  £765.37    |
-      | 4 | 010924/004 | £ 458.41   | Standard fee for category 1B-LSF YOUX £182.01 + travel costs + waiting costs + 20% vat on total =  £458.41    |
+      | 1 | 061224/001 | £ 1,527.29 | Standard fee for category 1A-HSF YOUX £1072.74 + travel costs + waiting costs + 20% vat on total =  £1,527.29 |
+      | 2 | 061224/002 | £ 1,226.96 | Standard fee for category 1A-LSF YOUX £822.47 + travel costs + waiting costs + 20% vat on total = £ 1,226.96  |
+      | 3 | 061224/003 | £ 765.37   | Standard fee for category 1B-HSF YOUX £437.81 + travel costs + waiting costs + 20% vat on total =  £765.37    |
+      | 4 | 061224/004 | £ 458.41   | Standard fee for category 1B-LSF YOUX £182.01 + travel costs + waiting costs + 20% vat on total =  £458.41    |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUX pricing check for YOUX with vat and travel and waiting costs with disbursement and disbursement vat
@@ -71,18 +71,18 @@ Feature: YOUX code Manual and Bulk load pricing
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 | Y             |          100 |                  100 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      822.47 | Y             |          100 |                  100 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      437.81 | Y             |          100 |                  100 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      182.01 | Y             |          100 |                  100 |                  100 |                20 |
+      | 1 | 061224/001 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 | Y             |          100 |                  100 |                  100 |                20 |
+      | 2 | 061224/002 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      822.47 | Y             |          100 |                  100 |                  100 |                20 |
+      | 3 | 061224/003 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      437.81 | Y             |          100 |                  100 |                  100 |                20 |
+      | 4 | 061224/004 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      182.01 | Y             |          100 |                  100 |                  100 |                20 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                                                         |
-      | 1 | 010924/001 | £ 1,647.29 | Standard fee for category 1A-HSF YOUX £1072.74 + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1,647.29 |
-      | 2 | 010924/002 | £ 1,346.96 | Standard fee for category 1A-LSF YOUX £822.47 + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat = £1,346.96   |
-      | 3 | 010924/003 | £ 885.37   | Standard fee for category 1B-HSF YOUX £437.81 + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £885.37    |
-      | 4 | 010924/004 | £ 578.41   | Standard fee for category 1B-LSF YOUX £182.01 + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £578.41    |
+      | 1 | 061224/001 | £ 1,647.29 | Standard fee for category 1A-HSF YOUX £1072.74 + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1,647.29 |
+      | 2 | 061224/002 | £ 1,346.96 | Standard fee for category 1A-LSF YOUX £822.47 + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat = £1,346.96   |
+      | 3 | 061224/003 | £ 885.37   | Standard fee for category 1B-HSF YOUX £437.81 + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £885.37    |
+      | 4 | 061224/004 | £ 578.41   | Standard fee for category 1B-LSF YOUX £182.01 + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £578.41    |
 
   Scenario: bulkload Crime Lower stage reached code YOUX pricing check for YOUX with vat and  without travel and waiting costs with disbursement and disbursement vat
     Given a test firm user is logged in CWA
@@ -91,31 +91,31 @@ Feature: YOUX code Manual and Bulk load pricing
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 | Y             |            0 |                    0 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      822.47 | Y             |            0 |                    0 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      437.81 | Y             |            0 |                    0 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      182.01 | Y             |            0 |                    0 |                  100 |                20 |
+      | 1 | 061224/001 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 | Y             |            0 |                    0 |                  100 |                20 |
+      | 2 | 061224/002 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      822.47 | Y             |            0 |                    0 |                  100 |                20 |
+      | 3 | 061224/003 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      437.81 | Y             |            0 |                    0 |                  100 |                20 |
+      | 4 | 061224/004 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      182.01 | Y             |            0 |                    0 |                  100 |                20 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                                                |
-      | 1 | 010924/001 | £ 1,407.29 | Standard fee for category 1A-HSF YOUX + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1,407.29 |
-      | 2 | 010924/002 | £ 1,106.96 | Standard fee for category 1A-LSF YOUX + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat = £1,106.96  |
-      | 3 | 010924/003 | £ 645.37   | Standard fee for category 1B-HSF YOUX + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £645.37   |
-      | 4 | 010924/004 | £ 338.41   | Standard fee for category 1B-LSF YOUX + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £338.41   |
+      | 1 | 061224/001 | £ 1,407.29 | Standard fee for category 1A-HSF YOUX + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £1,407.29 |
+      | 2 | 061224/002 | £ 1,106.96 | Standard fee for category 1A-LSF YOUX + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat = £1,106.96  |
+      | 3 | 061224/003 | £ 645.37   | Standard fee for category 1B-HSF YOUX + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £645.37   |
+      | 4 | 061224/004 | £ 338.41   | Standard fee for category 1B-LSF YOUX + travel costs + waiting costs + 20% vat on total + disbursement + disbursement vat =  £338.41   |
 
   @delete_outcome_after @manual_submission
   Scenario Outline: Pricing tests manual entry for YOUX
     Given user is on their "Crime Lower" submission details page
     When user adds outcomes for "Crime Lower" "Criminal Proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id |
-      | YOUX        |      01/9/2024 |           1A-HSF |     1072.74 | 010924/001 |         01-SEP-2024 | C1013          |       1 |
-      | YOUX        |      01/9/2024 |           1A-LSF |      822.47 | 010924/002 |         01-SEP-2024 | C1013          |       1 |
-      | YOUX        |      01/9/2024 |           1B-HSF |      437.81 | 010924/003 |         01-SEP-2024 | C1013          |       1 |
-      | YOUX        |      01/9/2024 |           1B-LSF |      182.01 | 010924/004 |         01-SEP-2024 | C1013          |       1 |
+      | YOUX        |      06/12/2024 |           1A-HSF |     1072.74 | 061224/001 |         06-DEC-2024 | C1013          |       1 |
+      | YOUX        |      06/12/2024 |           1A-LSF |      822.47 | 061224/002 |         06-DEC-2024 | C1013          |       1 |
+      | YOUX        |      06/12/2024 |           1B-HSF |      437.81 | 061224/003 |         06-DEC-2024 | C1013          |       1 |
+      | YOUX        |      06/12/2024 |           1B-LSF |      182.01 | 061224/004 |         06-DEC-2024 | C1013          |       1 |
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                  |
-      | 1 | 010924/001 | £ 1,072.74 | Priced at Fixed fee for YOUX at £1072.74 |
-      | 1 | 010924/002 | £ 822.47   | Priced at Fixed fee for YOUX at £822.47  |
-      | 1 | 010924/003 | £ 437.81   | Priced at Fixed fee for YOUX at £437.81  |
-      | 1 | 010924/004 | £ 182.01   | Priced at Fixed fee for YOUX at £182.01  |
+      | 1 | 061224/001 | £ 1,072.74 | Priced at Fixed fee for YOUX at £1072.74 |
+      | 1 | 061224/002 | £ 822.47   | Priced at Fixed fee for YOUX at £822.47  |
+      | 1 | 061224/003 | £ 437.81   | Priced at Fixed fee for YOUX at £437.81  |
+      | 1 | 061224/004 | £ 182.01   | Priced at Fixed fee for YOUX at £182.01  |

--- a/features/pricing/crime_lower/criminal_proceedings/youth_court/youy_pricing.feature
+++ b/features/pricing/crime_lower/criminal_proceedings/youth_court/youy_pricing.feature
@@ -50,18 +50,18 @@ Feature: YOUY code Bulk load pricing
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS |
-      | 1 | 051224/001 |     05/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |          100 |                  100 |
-      | 2 | 051224/002 |     05/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      884.61 | Y             |          100 |                  100 |
-      | 3 | 051224/003 |     05/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      500.99 | Y             |          100 |                  100 |
-      | 4 | 051224/004 |     05/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      232.53 | Y             |          100 |                  100 |
+      | 1 | 061224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |          100 |                  100 |
+      | 2 | 061224/002 |     06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      884.61 | Y             |          100 |                  100 |
+      | 3 | 061224/003 |     06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      500.99 | Y             |          100 |                  100 |
+      | 4 | 061224/004 |     06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      232.53 | Y             |          100 |                  100 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                               |
-      | 1 | 051224/001 | £ 1,369.40 | Standard fee for category 1A-HSF YOUY £1141.17 + ignore(travel costs + waiting costs) + 20% vat on total =  £1,369.40 |
-      | 2 | 051224/002 | £ 1,061.53 | Standard fee for category 1A-LSF YOUY £884.61 + ignore(travel costs + waiting costs) + 20% vat on total = £ 1,061.53  |
-      | 3 | 051224/003 | £ 601.19   | Standard fee for category 1B-HSF YOUY £500.99 + ignore(travel costs + waiting costs) + 20% vat on total =  £601.19    |
-      | 4 | 051224/004 | £ 279.04   | Standard fee for category 1B-LSF YOUY £232.53 + ignore(travel costs + waiting costs) + 20% vat on total =  £279.04    |
+      | 1 | 061224/001 | £ 1,369.40 | Standard fee for category 1A-HSF YOUY £1141.17 + ignore(travel costs + waiting costs) + 20% vat on total =  £1,369.40 |
+      | 2 | 061224/002 | £ 1,061.53 | Standard fee for category 1A-LSF YOUY £884.61 + ignore(travel costs + waiting costs) + 20% vat on total = £ 1,061.53  |
+      | 3 | 061224/003 | £ 601.19   | Standard fee for category 1B-HSF YOUY £500.99 + ignore(travel costs + waiting costs) + 20% vat on total =  £601.19    |
+      | 4 | 061224/004 | £ 279.04   | Standard fee for category 1B-LSF YOUY £232.53 + ignore(travel costs + waiting costs) + 20% vat on total =  £279.04    |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUY pricing check for YOUY with vat and travel and waiting costs with disbursement and disbursement vat

--- a/features/pricing/crime_lower/criminal_proceedings/youth_court/youy_pricing.feature
+++ b/features/pricing/crime_lower/criminal_proceedings/youth_court/youy_pricing.feature
@@ -8,18 +8,18 @@ Feature: YOUY code Bulk load pricing
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 |
-      | 2 | 010924/002 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      884.61 |
-      | 3 | 010924/003 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      500.99 |
-      | 4 | 010924/004 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      232.53 |
+      | 1 | 061224/001 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 |
+      | 2 | 061224/002 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      884.61 |
+      | 3 | 061224/003 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      500.99 |
+      | 4 | 061224/004 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      232.53 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value       | Comment                                        |
-      | 1 | 010924/001 | £ 1,141.17 | Standard fee for category 1A-HSF YOUY £1141.17 |
-      | 2 | 010924/002 | £ 884.61    | Standard fee for category 1A-LSF YOUY £884.61  |
-      | 3 | 010924/003 | £ 500.99    | Standard fee for category 1B-HSF YOUY £500.99  |
-      | 4 | 010924/004 | £ 232.53    | Standard fee for category 1B-LSF YOUY £232.53  |
+      | 1 | 061224/001 | £ 1,141.17 | Standard fee for category 1A-HSF YOUY £1141.17 |
+      | 2 | 061224/002 | £ 884.61    | Standard fee for category 1A-LSF YOUY £884.61  |
+      | 3 | 061224/003 | £ 500.99    | Standard fee for category 1B-HSF YOUY £500.99  |
+      | 4 | 061224/004 | £ 232.53    | Standard fee for category 1B-LSF YOUY £232.53  |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUY pricing check for YOUY with vat
@@ -29,18 +29,18 @@ Feature: YOUY code Bulk load pricing
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR |
-      | 1 | 010924/001 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |
-      | 2 | 010924/002 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      884.61 | Y             |
-      | 3 | 010924/003 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      500.99 | Y             |
-      | 4 | 010924/004 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      232.53 | Y             |
+      | 1 | 061224/001 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |
+      | 2 | 061224/002 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      884.61 | Y             |
+      | 3 | 061224/003 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      500.99 | Y             |
+      | 4 | 061224/004 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      232.53 | Y             |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                    |
-      | 1 | 010924/001 | £ 1,369.40 | Standard fee for category 1A-HSF YOUY £1,141.17  + vat 20% |
-      | 2 | 010924/002 | £ 1,061.53 | Standard fee for category 1A-LSF YOUY £884.61  + vat 20%   |
-      | 3 | 010924/003 | £ 601.19   | Standard fee for category 1B-HSF YOUY £500.99  + vat 20%   |
-      | 4 | 010924/004 | £ 279.04   | Standard fee for category 1B-LSF YOUY £232.53  + vat 20%   |
+      | 1 | 061224/001 | £ 1,369.40 | Standard fee for category 1A-HSF YOUY £1,141.17  + vat 20% |
+      | 2 | 061224/002 | £ 1,061.53 | Standard fee for category 1A-LSF YOUY £884.61  + vat 20%   |
+      | 3 | 061224/003 | £ 601.19   | Standard fee for category 1B-HSF YOUY £500.99  + vat 20%   |
+      | 4 | 061224/004 | £ 279.04   | Standard fee for category 1B-LSF YOUY £232.53  + vat 20%   |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUY pricing check for YOUY with vat and travel and waiting costs with vat
@@ -50,18 +50,18 @@ Feature: YOUY code Bulk load pricing
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS |
-      | 1 | 301223/001 |     30/12/2023 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |          100 |                  100 |
-      | 2 | 301223/002 |     30/12/2023 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      884.61 | Y             |          100 |                  100 |
-      | 3 | 301223/003 |     30/12/2023 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      500.99 | Y             |          100 |                  100 |
-      | 4 | 301223/004 |     30/12/2023 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      232.53 | Y             |          100 |                  100 |
+      | 1 | 051224/001 |     05/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |          100 |                  100 |
+      | 2 | 051224/002 |     05/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      884.61 | Y             |          100 |                  100 |
+      | 3 | 051224/003 |     05/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      500.99 | Y             |          100 |                  100 |
+      | 4 | 051224/004 |     05/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      232.53 | Y             |          100 |                  100 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                               |
-      | 1 | 301223/001 | £ 1,369.40 | Standard fee for category 1A-HSF YOUY £1141.17 + ignore(travel costs + waiting costs) + 20% vat on total =  £1,369.40 |
-      | 2 | 301223/002 | £ 1,061.53 | Standard fee for category 1A-LSF YOUY £884.61 + ignore(travel costs + waiting costs) + 20% vat on total = £ 1,061.53  |
-      | 3 | 301223/003 | £ 601.19   | Standard fee for category 1B-HSF YOUY £500.99 + ignore(travel costs + waiting costs) + 20% vat on total =  £601.19    |
-      | 4 | 301223/004 | £ 279.04   | Standard fee for category 1B-LSF YOUY £232.53 + ignore(travel costs + waiting costs) + 20% vat on total =  £279.04    |
+      | 1 | 051224/001 | £ 1,369.40 | Standard fee for category 1A-HSF YOUY £1141.17 + ignore(travel costs + waiting costs) + 20% vat on total =  £1,369.40 |
+      | 2 | 051224/002 | £ 1,061.53 | Standard fee for category 1A-LSF YOUY £884.61 + ignore(travel costs + waiting costs) + 20% vat on total = £ 1,061.53  |
+      | 3 | 051224/003 | £ 601.19   | Standard fee for category 1B-HSF YOUY £500.99 + ignore(travel costs + waiting costs) + 20% vat on total =  £601.19    |
+      | 4 | 051224/004 | £ 279.04   | Standard fee for category 1B-LSF YOUY £232.53 + ignore(travel costs + waiting costs) + 20% vat on total =  £279.04    |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUY pricing check for YOUY with vat and travel and waiting costs with disbursement and disbursement vat
@@ -71,18 +71,18 @@ Feature: YOUY code Bulk load pricing
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |          100 |                  100 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      884.61 | Y             |          100 |                  100 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      500.99 | Y             |          100 |                  100 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      232.53 | Y             |          100 |                  100 |                  100 |                20 |
+      | 1 | 061224/001 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |          100 |                  100 |                  100 |                20 |
+      | 2 | 061224/002 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      884.61 | Y             |          100 |                  100 |                  100 |                20 |
+      | 3 | 061224/003 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      500.99 | Y             |          100 |                  100 |                  100 |                20 |
+      | 4 | 061224/004 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      232.53 | Y             |          100 |                  100 |                  100 |                20 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                                                                 |
-      | 1 | 010924/001 | £ 1,489.40 | Standard fee for category 1A-HSF YOUY £1141.17 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,489.40 |
-      | 2 | 010924/002 | £ 1,181.53 | Standard fee for category 1A-LSF YOUY £884.61 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat = £1,181.53   |
-      | 3 | 010924/003 | £ 721.19   | Standard fee for category 1B-HSF YOUY £500.99 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £721.19    |
-      | 4 | 010924/004 | £ 399.04   | Standard fee for category 1B-LSF YOUY £232.53  + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £399.04   |
+      | 1 | 061224/001 | £ 1,489.40 | Standard fee for category 1A-HSF YOUY £1141.17 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,489.40 |
+      | 2 | 061224/002 | £ 1,181.53 | Standard fee for category 1A-LSF YOUY £884.61 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat = £1,181.53   |
+      | 3 | 061224/003 | £ 721.19   | Standard fee for category 1B-HSF YOUY £500.99 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £721.19    |
+      | 4 | 061224/004 | £ 399.04   | Standard fee for category 1B-LSF YOUY £232.53  + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £399.04   |
 
   @bullkload_submission
   Scenario: bulkload Crime Lower stage reached code YOUY pricing check for YOUY with vat and  without travel and waiting costs with disbursement and disbursement vat
@@ -92,15 +92,15 @@ Feature: YOUY code Bulk load pricing
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |            0 |                    0 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      884.61 | Y             |            0 |                    0 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      500.99 | Y             |            0 |                    0 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      232.53 | Y             |            0 |                    0 |                  100 |                20 |
+      | 1 | 061224/001 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 | Y             |            0 |                    0 |                  100 |                20 |
+      | 2 | 061224/002 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      884.61 | Y             |            0 |                    0 |                  100 |                20 |
+      | 3 | 061224/003 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      500.99 | Y             |            0 |                    0 |                  100 |                20 |
+      | 4 | 061224/004 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      232.53 | Y             |            0 |                    0 |                  100 |                20 |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value      | Comment                                                                                                                                                 |
-      | 1 | 010924/001 | £ 1,489.40 | Standard fee for category 1A-HSF YOUY £1141.17 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,489.40 |
-      | 2 | 010924/002 | £ 1,181.53 | Standard fee for category 1A-LSF YOUY £884.61 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat = £1,181.53   |
-      | 3 | 010924/003 | £ 721.19   | Standard fee for category 1B-HSF YOUY £500.99 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £721.19    |
-      | 4 | 010924/004 | £ 399.04   | Standard fee for category 1B-LSF YOUY £232.53  + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £399.04   |
+      | 1 | 061224/001 | £ 1,489.40 | Standard fee for category 1A-HSF YOUY £1141.17 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £1,489.40 |
+      | 2 | 061224/002 | £ 1,181.53 | Standard fee for category 1A-LSF YOUY £884.61 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat = £1,181.53   |
+      | 3 | 061224/003 | £ 721.19   | Standard fee for category 1B-HSF YOUY £500.99 + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £721.19    |
+      | 4 | 061224/004 | £ 399.04   | Standard fee for category 1B-LSF YOUY £232.53  + ignore(travel costs + waiting costs) + 20% vat on total + disbursement + disbursement vat =  £399.04   |

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youe_bulkload_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youe_bulkload_validations.feature
@@ -44,8 +44,8 @@ Feature: YOUE code Manual and Bulk load validations
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION |
-      | 1 | 010924/001 |     31/08/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |
-      | 2 | 310824/002 |     31/08/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |
+      | 1 | 061224/001 |     05/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |
+      | 2 | 061224/002 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |
     Then user should see the outcome results page
     And problem outcomes should equal 2
     And the following errors:
@@ -62,8 +62,8 @@ Feature: YOUE code Manual and Bulk load validations
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |     01/09/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 |
-      | 2 | 010924/001 |     01/09/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 |
+      | 1 | 061224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      822.47 |
+      | 2 | 061224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      822.47 |
     Then user should see the outcome results page
     And duplicate outcomes should equal 1
     And the following errors:
@@ -77,7 +77,7 @@ Feature: YOUE code Manual and Bulk load validations
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 311223/001 |     01/09/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 |
+      | 1 | 051224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      822.47 |
     Then user should see the outcome results page
     And successful outcomes should equal 1
     And problem outcomes should equal 0
@@ -90,7 +90,7 @@ Feature: YOUE code Manual and Bulk load validations
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 311223/001 |     31/12/2023 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 |
+      | 1 | 051224/001 |     05/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      822.47 |
     Then user should see the outcome results page
     And problem outcomes should equal 1
     And the following errors:
@@ -104,7 +104,7 @@ Feature: YOUE code Manual and Bulk load validations
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 311223/001 |     01/09/2024 |              1EW | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 |
+      | 1 | 061224/001 |     06/12/2024 |              1EW | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      822.47 |
     Then user should see the outcome results page
     And problem outcomes should equal 1
     And the invalid outcomes should equal 1
@@ -120,10 +120,10 @@ Feature: YOUE code Manual and Bulk load validations
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.48 | Y             |            0 |                    0 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      182.02 | Y             |            0 |                    0 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      919.97 | Y             |            0 |                    0 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      321.38 | Y             |            0 |                    0 |                  100 |                20 |
+      | 1 | 061224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      822.48 | Y             |            0 |                    0 |                  100 |                20 |
+      | 2 | 061224/002 |     06/12/2024 |               1B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      182.02 | Y             |            0 |                    0 |                  100 |                20 |
+      | 3 | 061224/003 |     06/12/2024 |               2A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      919.97 | Y             |            0 |                    0 |                  100 |                20 |
+      | 4 | 061224/004 |     06/12/2024 |               2B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      321.38 | Y             |            0 |                    0 |                  100 |                20 |
     Then user should see the outcome results page
     And problem outcomes should equal 4
     And the following errors:
@@ -140,7 +140,7 @@ Feature: YOUE code Manual and Bulk load validations
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | DSCC_NUMBER |
-      | 1 | 311223/001 |     01/09/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 |       12345 |
+      | 1 | 051224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      822.47 |       12345 |
     Then user should see the outcome results page
     And problem outcomes should equal 1
     And the following errors:
@@ -154,7 +154,7 @@ Feature: YOUE code Manual and Bulk load validations
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | MAAT_ID |
-      | 1 | 311223/001 |     01/09/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      822.47 | A       |
+      | 1 | 051224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      822.47 | A       |
     Then user should see the outcome results page
     And the invalid outcomes should equal 1
     And the following errors:

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youe_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youe_validations.feature
@@ -10,7 +10,7 @@ Feature: YOUE code Manual and Bulk load validations
       | YOUE |
     And the following outcomes are bulkloaded:
       | # | UFN        | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | REP_ORDER_DATE | PROFIT_COST | STANDARD_FEE_CAT |
-      | 1 | 010924/001 | CP19         |           01/9/2024 | Y           | C1013          |                        1 |    01-SEP-2024 |      822.47 |               1A |
+      | 1 | 061224/001 | CP19         |          06/12/2024 | Y           | C1013          |                        1 |    06-DEC-2024 |      822.47 |               1A |
     Then the following results are expected:
       | # | ERROR_CODE_OR_MESSAGE            |
       | 1 | CP19 is not a valid OUTCOME_CODE |
@@ -20,7 +20,7 @@ Feature: YOUE code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
-      | YOUE        |    28-OCT-2024 |               1A |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         | 1234567 |
+      | YOUE        |    06-DEC-2024 |               1A |           0 | 061224/001 |         06-DEC-2024 | C1013          | CP19         | 1234567 |
     Then the outcome does not save and gives an error containing:
       """
       Outcome Code - ID CP19 for the flexfield segment Outcome Code does not exist in the value set XXLSC_CASE_OUTCOME_CODE_CL.
@@ -31,7 +31,7 @@ Feature: YOUE code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
-      | YOUE        |                |                  |         100 | 010924/001 |         01-SEP-2024 | C1013          | CP18         |         |
+      | YOUE        |                |                  |         100 | 061224/001 |         06-DEC-2024 | C1013          | CP18         |         |
     Then the outcome does not save and this popup error appears:
       """
       A value must be entered for "Representation Order Date".
@@ -74,7 +74,7 @@ Feature: YOUE code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id | dscc_number |
-      | YOUE        |    28-OCT-2024 |               1A |           0 | 010924/001 |         01-SEP-2024 | C1013          | 1234567 |           1 |
+      | YOUE        |    06-DEC-2024 |               1A |           0 | 061224/001 |         05-DEC-2024 | C1013          | 1234567 |           1 |
     Then the outcome does not save and gives an error containing:
       """
       The Representation Order Date must be before the case concluded date. Please enter a valid value.
@@ -86,13 +86,14 @@ Feature: YOUE code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id | dscc_number |
-      | YOUE        |     01-09-2024 |               1A |           0 | 010924/001 |         30-AUG-2024 | C1013          | 1234567 |  201012345A |
+      | YOUE        |     06-12-2024 |               1A |           0 | 061224/001 |         05-DEC-2024 | C1013          | 1234567 |  201012345A |
     Then the outcome does not save and gives an error containing:
       """
       Case Concluded Date is before Case Start Date
       The Representation Order Date must be before the case concluded date. Please enter a valid value.
       """
- @manual_submission
+
+  @manual_submission
   Scenario: Manually enter YOUE outcomes and test some drop down lists are correct
     Given user is on their "CRIME LOWER" submission details page
     When user enters an outcome for "Crime Lower" "criminal proceedings" with fields like this:

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youf_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youf_validations.feature
@@ -10,7 +10,7 @@ Feature: YOUF code Manual and Bulk load validations
       | YOUF |
     And the following outcomes are bulkloaded:
       | # | UFN        | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | REP_ORDER_DATE | PROFIT_COST | STANDARD_FEE_CAT |
-      | 1 | 010924/001 | CP19         |           01/9/2024 | Y           | C1013          |                        1 |    01-SEP-2024 |     1072.74 |               1A |
+      | 1 | 061224/001 | CP19         |          06/12/2024 | Y           | C1013          |                        1 |    06-DEC-2024 |     1072.74 |               1A |
     Then the following results are expected:
       | # | ERROR_CODE_OR_MESSAGE            |
       | 1 | CP19 is not a valid OUTCOME_CODE |
@@ -20,7 +20,7 @@ Feature: YOUF code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
-      | YOUF        |    28-OCT-2024 |               1B |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         | 1234567 |
+      | YOUF        |    06-DEC-2024 |               1B |           0 | 061224/001 |         06-DEC-2024 | C1013          | CP19         | 1234567 |
     Then the outcome does not save and gives an error containing:
       """
       Outcome Code - ID CP19 for the flexfield segment Outcome Code does not exist in the value set XXLSC_CASE_OUTCOME_CODE_CL.
@@ -31,7 +31,7 @@ Feature: YOUF code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
-      | YOUF        |                |                  |         100 | 010924/001 |         01-SEP-2024 | C1013          | CP18         |         |
+      | YOUF        |                |                  |         100 | 061224/001 |         06-DEC-2024 | C1013          | CP18         |         |
     Then the outcome does not save and this popup error appears:
       """
       A value must be entered for "Representation Order Date".
@@ -77,10 +77,10 @@ Feature: YOUF code Manual and Bulk load validations
       | YOUF |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1072.75 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      437.82 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1335.68 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      737.09 |
+      | 1 | 061224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |     1072.75 |
+      | 2 | 061224/002 |     06/12/2024 |               1B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      437.82 |
+      | 3 | 061224/003 |     06/12/2024 |               2A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |     1335.68 |
+      | 4 | 061224/004 |     06/12/2024 |               2B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      737.09 |
     Then user should see the outcome results page
     And problem outcomes should equal 4
     And the following errors:
@@ -95,13 +95,14 @@ Feature: YOUF code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id | dscc_number |
-      | YOUF        |    28-OCT-2024 |               1A |           0 | 010924/001 |         01-SEP-2024 | C1013          | 1234567 |           1 |
+      | YOUF        |    06-DEC-2024 |               1A |           0 | 061224/001 |         05-DEC-2024 | C1013          | 1234567 |           1 |
     Then the outcome does not save and gives an error containing:
       """
       The Representation Order Date must be before the case concluded date. Please enter a valid value.
       The DSCC Number you have reported is invalid. DSCC Numbers must be 10 characters long and in the format yymmnnnnnl. Please enter a valid value in the DSCC Number field.
       """
-@manual_submission
+
+  @manual_submission
   Scenario: Manually enter YOUF outcomes and test some drop down lists are correct
     Given user is on their "CRIME LOWER" submission details page
     When user enters an outcome for "Crime Lower" "criminal proceedings" with fields like this:

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youk_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youk_validations.feature
@@ -10,7 +10,7 @@ Feature: YOUK code Manual and Bulk load validations
       | YOUK |
     And the following outcomes are bulkloaded:
       | # | UFN        | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | REP_ORDER_DATE | PROFIT_COST | STANDARD_FEE_CAT |
-      | 1 | 010924/001 | CP19         |           01/9/2024 | Y           | C1013          |                        1 |    01-SEP-2024 |      884.61 |               1A |
+      | 1 | 061224/001 | CP19         |          06/12/2024 | Y           | C1013          |                        1 |    06-DEC-2024 |      884.61 |               1A |
     Then the following results are expected:
       | # | ERROR_CODE_OR_MESSAGE            |
       | 1 | CP19 is not a valid OUTCOME_CODE |
@@ -20,7 +20,7 @@ Feature: YOUK code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
-      | YOUK        |    28-OCT-2024 |               1C |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         | 1234567 |
+      | YOUK        |    06-DEC-2024 |               1C |           0 | 061224/001 |         06-DEC-2024 | C1013          | CP19         | 1234567 |
     Then the outcome does not save and gives an error containing:
       """
       Outcome Code - ID CP19 for the flexfield segment Outcome Code does not exist in the value set XXLSC_CASE_OUTCOME_CODE_CL.
@@ -31,7 +31,7 @@ Feature: YOUK code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
-      | YOUK        |                |                  |         100 | 010924/001 |         01-SEP-2024 | C1013          | CP18         |         |
+      | YOUK        |                |                  |         100 | 061224/001 |         06-DEC-2024 | C1013          | CP18         |         |
     Then the outcome does not save and this popup error appears:
       """
       A value must be entered for "Representation Order Date".
@@ -77,10 +77,10 @@ Feature: YOUK code Manual and Bulk load validations
       | YOUK |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      884.62 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      232.54 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      995.74 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      397.15 |
+      | 1 | 061224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      884.62 |
+      | 2 | 061224/002 |     06/12/2024 |               1B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      232.54 |
+      | 3 | 061224/003 |     06/12/2024 |               2A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      995.74 |
+      | 4 | 061224/004 |     06/12/2024 |               2B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      397.15 |
     Then user should see the outcome results page
     And problem outcomes should equal 4
     And the following errors:
@@ -95,7 +95,7 @@ Feature: YOUK code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id | dscc_number |
-      | YOUK        |    28-OCT-2024 |               1A |           0 | 010924/001 |         01-SEP-2024 | C1013          | 1234567 |           1 |
+      | YOUK        |    06-DEC-2024 |               1A |           0 | 061224/001 |         05-DEC-2024 | C1013          | 1234567 |           1 |
     Then the outcome does not save and gives an error containing:
       """
       The Representation Order Date must be before the case concluded date. Please enter a valid value.
@@ -107,13 +107,14 @@ Feature: YOUK code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id | dscc_number |
-      | YOUK        |     01-09-2024 |               1A |           0 | 010924/001 |         30-AUG-2024 | C1013          | 1234567 |  201012345A |
+      | YOUK        |     06-12-2024 |               1A |           0 | 061224/001 |         05-DEC-2024 | C1013          | 1234567 |  201012345A |
     Then the outcome does not save and gives an error containing:
       """
       Case Concluded Date is before Case Start Date
       The Representation Order Date must be before the case concluded date. Please enter a valid value.
       """
-@manual_submission
+
+  @manual_submission
   Scenario: Manually enter YOUK outcomes and test some drop down lists are correct
     Given user is on their "CRIME LOWER" submission details page
     When user enters an outcome for "Crime Lower" "criminal proceedings" with fields like this:

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youl_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youl_validations.feature
@@ -10,7 +10,7 @@ Feature: YOUL code Manual and Bulk load validations
       | YOUL |
     And the following outcomes are bulkloaded:
       | # | UFN        | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | REP_ORDER_DATE | PROFIT_COST | STANDARD_FEE_CAT |
-      | 1 | 010924/001 | CP19         |           01/9/2024 | Y           | C1013          |                        1 |    01-SEP-2024 |     1141.17 |               1A |
+      | 1 | 061224/001 | CP19         |          06/12/2024 | Y           | C1013          |                        1 |    06-DEC-2024 |     1141.17 |               1A |
     Then the following results are expected:
       | # | ERROR_CODE_OR_MESSAGE            |
       | 1 | CP19 is not a valid OUTCOME_CODE |
@@ -20,7 +20,7 @@ Feature: YOUL code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
-      | YOUL        |    28-OCT-2024 |               1D |           0 | 010924/001 |         01-SEP-2024 | C1013          | CP19         | 1234567 |
+      | YOUL        |    06-DEC-2024 |               1D |           0 | 061224/001 |         06-DEC-2024 | C1013          | CP19         | 1234567 |
     Then the outcome does not save and gives an error containing:
       """
       Outcome Code - ID CP19 for the flexfield segment Outcome Code does not exist in the value set XXLSC_CASE_OUTCOME_CODE_CL.
@@ -31,7 +31,7 @@ Feature: YOUL code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | outcome_code | maat_id |
-      | YOUL        |                |                  |         100 | 010924/001 |         01-SEP-2024 | C1013          | CP18         |         |
+      | YOUL        |                |                  |         100 | 061224/001 |         06-DEC-2024 | C1013          | CP18         |         |
     Then the outcome does not save and this popup error appears:
       """
       A value must be entered for "Representation Order Date".
@@ -77,10 +77,10 @@ Feature: YOUL code Manual and Bulk load validations
       | YOUL |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | OUTCOME_CODE | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |      01/9/2024 |               1A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1141.18 |
-      | 2 | 010924/002 |      01/9/2024 |               1B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      500.98 |
-      | 3 | 010924/003 |      01/9/2024 |               2A | CP18         |           01/9/2024 | Y           | C1013          |                        1 |     1430.45 |
-      | 4 | 010924/004 |      01/9/2024 |               2B | CP18         |           01/9/2024 | Y           | C1013          |                        1 |      831.86 |
+      | 1 | 061224/001 |     06/12/2024 |               1A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |     1141.18 |
+      | 2 | 061224/002 |     06/12/2024 |               1B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      500.98 |
+      | 3 | 061224/003 |     06/12/2024 |               2A | CP18         |          06/12/2024 | Y           | C1013          |                        1 |     1430.45 |
+      | 4 | 061224/004 |     06/12/2024 |               2B | CP18         |          06/12/2024 | Y           | C1013          |                        1 |      831.86 |
     Then user should see the outcome results page
     And problem outcomes should equal 4
     And the following errors:
@@ -95,14 +95,14 @@ Feature: YOUL code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id | dscc_number |
-      | YOUL        |    28-OCT-2024 |               1B |           0 | 010924/001 |         01-SEP-2024 | C1013          | 1234567 |           1 |
+      | YOUL        |    06-DEC-2024 |               1B |           0 | 061224/001 |         05-DEC-2024 | C1013          | 1234567 |           1 |
     Then the outcome does not save and gives an error containing:
       """
       The Representation Order Date must be before the case concluded date. Please enter a valid value.
       The DSCC Number you have reported is invalid. DSCC Numbers must be 10 characters long and in the format yymmnnnnnl. Please enter a valid value in the DSCC Number field.
       """
 
-@manual_submission
+  @manual_submission
   Scenario: Manually enter YOUL outcomes and test some drop down lists are correct
     Given user is on their "CRIME LOWER" submission details page
     When user enters an outcome for "Crime Lower" "criminal proceedings" with fields like this:

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youx_bulkload_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youx_bulkload_validations.feature
@@ -42,8 +42,8 @@ Feature: YOUX code Manual and Bulk load validations
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION |
-      | 1 | 010924/001 |     31/08/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |
-      | 2 | 310824/002 |     31/08/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |
+      | 1 | 061224/001 |     05/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |
+      | 2 | 061224/002 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |
     Then user should see the outcome results page
     And problem outcomes should equal 2
     And the following errors:
@@ -60,8 +60,8 @@ Feature: YOUX code Manual and Bulk load validations
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |     01/09/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 |
-      | 2 | 010924/001 |     01/09/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 |
+      | 1 | 061224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 |
+      | 2 | 061224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 |
     Then user should see the outcome results page
     And duplicate outcomes should equal 1
     And the following errors:
@@ -75,20 +75,20 @@ Feature: YOUX code Manual and Bulk load validations
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 311223/001 |     01/09/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 |
+      | 1 | 051224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 |
     Then user should see the outcome results page
     And successful outcomes should equal 1
     And problem outcomes should equal 0
     Then user confirms the submission
 
-  Scenario: Bulkload Crime Lower stage reached code YOUX validation check rep order date has to be after 01/01/2024 which is the pricing scheme date in tst
+  Scenario: Bulkload Crime Lower stage reached code YOUX validation check rep order date has to be on or after 06/12/2024 which is the pricing scheme date in tst
     Given a test firm user is logged in CWA
     And user prepares to submit outcomes for test provider "CRIME LOWER#25"
     Given the following Matter Types are chosen:
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 311223/001 |     31/12/2023 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 |
+      | 1 | 051224/001 |     05/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 |
     Then user should see the outcome results page
     And problem outcomes should equal 1
     And the following errors:
@@ -102,7 +102,7 @@ Feature: YOUX code Manual and Bulk load validations
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 311223/001 |     01/09/2024 |              1EW |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 |
+      | 1 | 061224/001 |     06/12/2024 |              1EW |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 |
     Then user should see the outcome results page
     And problem outcomes should equal 1
     And the invalid outcomes should equal 1
@@ -118,10 +118,10 @@ Feature: YOUX code Manual and Bulk load validations
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      822.48 | Y             |            0 |                    0 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      182.02 | Y             |            0 |                    0 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |      919.97 | Y             |            0 |                    0 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      321.38 | Y             |            0 |                    0 |                  100 |                20 |
+      | 1 | 061224/001 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      822.48 | Y             |            0 |                    0 |                  100 |                20 |
+      | 2 | 061224/002 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      182.02 | Y             |            0 |                    0 |                  100 |                20 |
+      | 3 | 061224/003 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |      919.97 | Y             |            0 |                    0 |                  100 |                20 |
+      | 4 | 061224/004 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      321.38 | Y             |            0 |                    0 |                  100 |                20 |
     Then user should see the outcome results page
     And problem outcomes should equal 4
     And the following errors:
@@ -138,7 +138,7 @@ Feature: YOUX code Manual and Bulk load validations
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | DSCC_NUMBER |
-      | 1 | 311223/001 |     01/09/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 |       12345 |
+      | 1 | 051224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 |       12345 |
     Then user should see the outcome results page
     And problem outcomes should equal 1
     And the following errors:
@@ -152,7 +152,7 @@ Feature: YOUX code Manual and Bulk load validations
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | MAAT_ID |
-      | 1 | 311223/001 |     01/09/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1072.74 | A       |
+      | 1 | 051224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1072.74 | A       |
     Then user should see the outcome results page
     And the invalid outcomes should equal 1
     And the following errors:
@@ -169,6 +169,6 @@ Feature: YOUX code Manual and Bulk load validations
       | YOUX |
     And the following outcomes are bulkloaded:
       | # | UFN        | WORK_CONCLUDED_DATE | REP_ORDER_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | STANDARD_FEE_CAT | PROFIT_COST |
-      | 1 | 010924/001 |           01/9/2024 |      01/9/2024 | Y           | C1013          |                        1 |           1A-HSF |     1072.74 |
+      | 1 | 061224/001 |           06/12/2024 |      06/12/2024 | Y           | C1013          |                        1 |           1A-HSF |     1072.74 |
     Then user should see the outcome results page
     And the successful outcomes should equal 1

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youx_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youx_validations.feature
@@ -5,7 +5,7 @@ Feature: YOUX code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id |
-      | YOUX        |    01-SEP-2024 |           1A-HSF |     1072.74 | 010924/001 |         01-SEP-2024 | C1013          | 1234567 |
+      | YOUX        |    06-DEC-2024 |           1A-HSF |     1072.74 | 061224/001 |         06-DEC-2024 | C1013          | 1234567 |
     Then the outcome saves successfully
 
   @manual_submission
@@ -13,7 +13,7 @@ Feature: YOUX code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id |
-      | YOUX        |                |                  |         100 | 010924/001 |         01-SEP-2024 | C1013          |         |
+      | YOUX        |                |                  |         100 | 061224/001 |         06-DEC-2024 | C1013          |         |
     Then the outcome does not save and this popup error appears:
       """
       A value must be entered for "Representation Order Date".
@@ -38,7 +38,7 @@ Feature: YOUX code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id | dscc_number |
-      | YOUX        |    01-SEP-2024 |           1A-LSF |      822.47 | 010924/001 |         01-SEP-2024 | C1013          | 1234567 |           1 |
+      | YOUX        |    06-DEC-2024 |           1A-LSF |      822.47 | 061224/001 |         06-DEC-2024 | C1013          | 1234567 |           1 |
     Then the outcome does not save and gives an error containing:
       """
       The DSCC Number you have reported is invalid. DSCC Numbers must be 10 characters long and in the format yymmnnnnnl. Please enter a valid value in the DSCC Number field.
@@ -49,7 +49,7 @@ Feature: YOUX code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id | dscc_number |
-      | YOUX        |     01-09-2024 |           1A-LSF |           0 | 010924/001 |         30-AUG-2024 | C1013          | 1234567 |  201012345A |
+      | YOUX        |     06/12/2024 |           1A-LSF |           0 | 061224/001 |         05-DEC-2024 | C1013          | 1234567 |  201012345A |
     Then the outcome does not save and gives an error containing:
       """
       Case Concluded Date is before Case Start Date

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youy_bulkload_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youy_bulkload_validations.feature
@@ -42,8 +42,8 @@ Feature: YOUY code Manual and Bulk load validations
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION |
-      | 1 | 010924/001 |     31/08/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |
-      | 2 | 310824/002 |     31/08/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |
+      | 1 | 061224/001 |     05/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |
+      | 2 | 051224/002 |     05/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |
     Then user should see the outcome results page
     And problem outcomes should equal 2
     And the following errors:
@@ -60,8 +60,8 @@ Feature: YOUY code Manual and Bulk load validations
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 010924/001 |     01/09/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 |
-      | 2 | 010924/001 |     01/09/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 |
+      | 1 | 061224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 |
+      | 2 | 061224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 |
     Then user should see the outcome results page
     And duplicate outcomes should equal 1
     And the following errors:
@@ -75,20 +75,20 @@ Feature: YOUY code Manual and Bulk load validations
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 311223/001 |     01/09/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 |
+      | 1 | 061224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 |
     Then user should see the outcome results page
     And successful outcomes should equal 1
     And problem outcomes should equal 0
     Then user confirms the submission
 
-  Scenario: Bulkload Crime Lower stage reached code YOUY validation check rep order date has to be after 01/01/2024 which is the pricing scheme date in tst
+  Scenario: Bulkload Crime Lower stage reached code YOUY validation check rep order date has to be on or after 06/12/2024 which is the pricing scheme date in tst
     Given a test firm user is logged in CWA
     And user prepares to submit outcomes for test provider "CRIME LOWER#25"
     Given the following Matter Types are chosen:
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 311223/001 |     31/12/2023 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 |
+      | 1 | 051224/001 |     05/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 |
     Then user should see the outcome results page
     And problem outcomes should equal 1
     And the following errors:
@@ -102,7 +102,7 @@ Feature: YOUY code Manual and Bulk load validations
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST |
-      | 1 | 311223/001 |     01/09/2024 |              1EW |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 |
+      | 1 | 061224/001 |     06/12/2024 |              1EW |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 |
     Then user should see the outcome results page
     And problem outcomes should equal 1
     And the invalid outcomes should equal 1
@@ -118,10 +118,10 @@ Feature: YOUY code Manual and Bulk load validations
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | VAT_INDICATOR | TRAVEL_COSTS | TRAVEL_WAITING_COSTS | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT |
-      | 1 | 010924/001 |      01/9/2024 |           1A-LSF |           01/9/2024 | Y           | C1013          |                        1 |      822.48 | Y             |            0 |                    0 |                  100 |                20 |
-      | 2 | 010924/002 |      01/9/2024 |           1B-LSF |           01/9/2024 | Y           | C1013          |                        1 |      182.02 | Y             |            0 |                    0 |                  100 |                20 |
-      | 3 | 010924/003 |      01/9/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |      919.97 | Y             |            0 |                    0 |                  100 |                20 |
-      | 4 | 010924/004 |      01/9/2024 |           1B-HSF |           01/9/2024 | Y           | C1013          |                        1 |      321.38 | Y             |            0 |                    0 |                  100 |                20 |
+      | 1 | 061224/001 |      06/12/2024 |           1A-LSF |           06/12/2024 | Y           | C1013          |                        1 |      822.48 | Y             |            0 |                    0 |                  100 |                20 |
+      | 2 | 061224/002 |      06/12/2024 |           1B-LSF |           06/12/2024 | Y           | C1013          |                        1 |      182.02 | Y             |            0 |                    0 |                  100 |                20 |
+      | 3 | 061224/003 |      06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |      919.97 | Y             |            0 |                    0 |                  100 |                20 |
+      | 4 | 061224/004 |      06/12/2024 |           1B-HSF |           06/12/2024 | Y           | C1013          |                        1 |      321.38 | Y             |            0 |                    0 |                  100 |                20 |
     Then user should see the outcome results page
     And problem outcomes should equal 4
     And the following errors:
@@ -138,7 +138,7 @@ Feature: YOUY code Manual and Bulk load validations
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | DSCC_NUMBER |
-      | 1 | 311223/001 |     01/09/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 |       12345 |
+      | 1 | 061224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 |       12345 |
     Then user should see the outcome results page
     And problem outcomes should equal 1
     And the following errors:
@@ -152,7 +152,7 @@ Feature: YOUY code Manual and Bulk load validations
       | YOUY |
     And the following outcomes are bulkloaded:
       | # | UFN        | REP_ORDER_DATE | STANDARD_FEE_CAT | WORK_CONCLUDED_DATE | YOUTH_COURT | POLICE_STATION | NUMBER_OF_POLICE_STATION | PROFIT_COST | MAAT_ID |
-      | 1 | 311223/001 |     01/09/2024 |           1A-HSF |           01/9/2024 | Y           | C1013          |                        1 |     1141.17 | A       |
+      | 1 | 061224/001 |     06/12/2024 |           1A-HSF |           06/12/2024 | Y           | C1013          |                        1 |     1141.17 | A       |
     Then user should see the outcome results page
     And the invalid outcomes should equal 1
     And the following errors:

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youy_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youy_validations.feature
@@ -5,7 +5,7 @@ Feature: YOUY code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id |
-      | YOUY        |    01-SEP-2024 |           1A-LSF |      884.61 | 010924/001 |         01-SEP-2024 | C1013          | 1234567 |
+      | YOUY        |    06-DEC-2024 |           1A-LSF |      884.61 | 061224/001 |         06-DEC-2024 | C1013          | 1234567 |
     Then the outcome saves successfully
 
   @manual_submission
@@ -13,7 +13,7 @@ Feature: YOUY code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id |
-      | YOUY        |                |                  |         100 | 010924/001 |         01-SEP-2024 | C1013          |         |
+      | YOUY        |                |                  |         100 | 061224/001 |         06-DEC-2024 | C1013          |         |
     Then the outcome does not save and this popup error appears:
       """
       A value must be entered for "Representation Order Date".
@@ -38,7 +38,7 @@ Feature: YOUY code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id | dscc_number |
-      | YOUY        |    01-SEP-2024 |           1A-LSF |      884.61 | 010924/001 |         01-SEP-2024 | C1013          | 1234567 |           1 |
+      | YOUY        |    06-DEC-2024 |           1A-LSF |      884.61 | 061224/001 |         06-DEC-2024 | C1013          | 1234567 |           1 |
     Then the outcome does not save and gives an error containing:
       """
       The DSCC Number you have reported is invalid. DSCC Numbers must be 10 characters long and in the format yymmnnnnnl. Please enter a valid value in the DSCC Number field.
@@ -49,7 +49,7 @@ Feature: YOUY code Manual and Bulk load validations
     Given user is on their "CRIME LOWER" submission details page
     When user adds outcomes for "Crime Lower" "criminal proceedings" with fields like this:
       | matter_type | rep_order_date | standard_fee_cat | profit_cost | ufn        | work_concluded_date | police_station | maat_id | dscc_number |
-      | YOUY        |     01-09-2024 |           1A-LSF |           0 | 010924/001 |         30-AUG-2024 | C1013          | 1234567 |  201012345A |
+      | YOUY        |     06-12-2024 |           1A-LSF |           0 | 061224/001 |         05-DEC-2024 | C1013          | 1234567 |  201012345A |
     Then the outcome does not save and gives an error containing:
       """
       Case Concluded Date is before Case Start Date


### PR DESCRIPTION
## What does this pull request do?

Post-release to production have changed dates for youth court to 06-12-2024, which is the valid date for youth court validation and pricing, 

## Why make these changes?
Change dates in accordance with the guidance.

## Checklist

Not ticketed eork