### PR TITLE
Removing matter type 36 from youe/f/k/l tests

### DIFF
--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youe_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youe_validations.feature
@@ -67,7 +67,6 @@ Feature: YOUE code Manual and Bulk load validations
       |                                                    14-Anti-social behaviour orders |
       |                                                          15-Sexual offender orders |
       |                                                    16-Other prescribed proceedings |
-      |                           36-Breach of part 1 Injunctions under the ASBCP Act 2014 |
 
   @manual_submission
   Scenario: Manually enter YOUE outcomes , check for DSCC format validation

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youf_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youf_validations.feature
@@ -67,7 +67,6 @@ Feature: YOUF code Manual and Bulk load validations
       |                                                    14-Anti-social behaviour orders |
       |                                                          15-Sexual offender orders |
       |                                                    16-Other prescribed proceedings |
-      |                           36-Breach of part 1 Injunctions under the ASBCP Act 2014 |
 
   @bullkload_submission
   Scenario: Bulkload Crime Lower stage reached code YOUF VALIDATION4 check for YOUF with wrong profit cost values

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youk_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youk_validations.feature
@@ -67,7 +67,6 @@ Feature: YOUK code Manual and Bulk load validations
       |                                                    14-Anti-social behaviour orders |
       |                                                          15-Sexual offender orders |
       |                                                    16-Other prescribed proceedings |
-      |                           36-Breach of part 1 Injunctions under the ASBCP Act 2014 |
 
   @bullkload_submission
   Scenario: Bulkload Crime Lower stage reached code YOUK VALIDATION4 check for YOUK with wrong profit cost values

--- a/features/validations/crime_lower/criminal_proceedings/youth_court/youl_validations.feature
+++ b/features/validations/crime_lower/criminal_proceedings/youth_court/youl_validations.feature
@@ -67,7 +67,6 @@ Feature: YOUL code Manual and Bulk load validations
       |                                                    14-Anti-social behaviour orders |
       |                                                          15-Sexual offender orders |
       |                                                    16-Other prescribed proceedings |
-      |                           36-Breach of part 1 Injunctions under the ASBCP Act 2014 |
 
   @bullkload_submission
   Scenario: Bulkload Crime Lower stage reached code YOUL VALIDATION4 check for YOUL with wrong profit cost values


### PR DESCRIPTION
## What does this pull request do?

Please describe what you did.
Removed matter typpe 36 from matter type drop down in feature tests:
youe_validations.feature
youf_validations.feature
youk_validations.feature
youl_validations.feature

## Why make these changes?

Please describe why the changes were needed.
Given the change made by TA-2956, these tests needed to be updated to check for what is in the matter type field, as 36 would have been disabled.

## Checklist

- [ ] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-2998
