### PR TITLE
TA-3080 IAXL:IDAS Completed Matter. with o/c IX only

### DIFF
--- a/features/pricing/legal_help/immigration/Illegal_migration_act/dtw_pricing.feature
+++ b/features/pricing/legal_help/immigration/Illegal_migration_act/dtw_pricing.feature
@@ -17,45 +17,27 @@ Feature: Validation for Illegal Immigration Act
     And the following outcomes are bulkloaded:
       | #  | CASE_ID | UFN        | CLAIM_TYPE | CASE_START_DATE | WORK_CONCLUDED_DATE | OUTCOME_CODE | TRAVEL_COSTS | PROFIT_COST | COUNSEL_COST | VAT_INDICATOR | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT | EXEMPTION_CRITERIA_SATISFIED |
       |  1 |     001 | 151223/001 | CM         |      15/12/2023 |          15/12/2023 | IX           |          100 |         100 |          100 | Y             |               100.00 |                20 | TR001                        |
-      |  2 |     002 | 151223/002 | SC         |      15/12/2023 |          15/12/2023 | --           |          100 |         100 |          100 | N             |               100.00 |                20 | TR001                        |
       |  3 |     003 | 151223/003 | CM         |      15/12/2023 |          15/12/2023 | IX           |              |         100 |          100 | Y             |               100.00 |                20 | TR001                        |
-      |  4 |     004 | 151223/004 | SC         |      15/12/2023 |          15/12/2023 | --           |              |         100 |          100 | N             |               100.00 |                20 | TR001                        |
       |  5 |     005 | 151223/005 | CM         |      15/12/2023 |          15/12/2023 | IX           |          100 |           0 |          100 | Y             |               100.00 |                20 | TR001                        |
-      |  6 |     002 | 151223/006 | SC         |      15/12/2023 |          15/12/2023 | --           |          100 |           0 |          100 | N             |               100.00 |                20 | TR001                        |
       |  7 |     007 | 151223/007 | CM         |      15/12/2023 |          15/12/2023 | IX           |          100 |         100 |          100 | Y             |                    0 |                 0 | TR001                        |
-      |  8 |     008 | 151223/008 | SC         |      15/12/2023 |          15/12/2023 | --           |          100 |         100 |          100 | N             |                    0 |                 0 | TR001                        |
       |  9 |     009 | 151223/009 | CM         |      15/12/2023 |          15/12/2023 | IX           |              |         100 |          100 | Y             |                  100 |                 0 | TR001                        |
-      | 10 |     010 | 151223/010 | SC         |      15/12/2023 |          15/12/2023 | --           |              |         100 |          100 | N             |                  100 |                 0 | TR001                        |
       | 11 |     011 | 151223/011 | CM         |      15/12/2023 |          15/12/2023 | IX           |              |         100 |          100 | Y             |                    0 |                 0 | TR001                        |
-      | 12 |     012 | 151223/012 | SC         |      15/12/2023 |          15/12/2023 | --           |              |         100 |          100 | N             |                    0 |                 0 | TR001                        |
       | 13 |     013 | 151223/013 | CM         |      15/12/2023 |          15/12/2023 | IX           |              |           0 |            0 | Y             |                  100 |                 0 | TR001                        |
-      | 14 |     014 | 151223/014 | SC         |      15/12/2023 |          15/12/2023 | --           |              |           0 |            0 | N             |                  100 |                 0 | TR001                        |
       | 15 |     015 | 151223/015 | CM         |      15/12/2023 |          15/12/2023 | IX           |          100 |           0 |            0 | Y             |                    0 |                 0 | TR001                        |
-      | 16 |     016 | 151223/016 | SC         |      15/12/2023 |          15/12/2023 | --           |          100 |           0 |            0 | N             |                    0 |                 0 | TR001                        |
       | 17 |     017 | 151223/017 | CM         |      15/12/2023 |          15/12/2023 | IX           |          100 |           0 |          100 | Y             |                    0 |                 0 | TR001                        |
-      | 18 |     018 | 151223/018 | SC         |      15/12/2023 |          15/12/2023 | --           |          100 |           0 |          100 | N             |                    0 |                 0 | TR001                        |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | #  | UFN        | Value    | Comment                                                                                                                                                                                |
       |  1 | 151223/001 | £ 480.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£100) + disbursement vat(£20) + pc/cc vat(£60) + DTW cost(£100)                                 |
-      |  2 | 151223/002 | £ 420.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£100) + disbursement vat(£20) + pc/cc vat(£0) + DTW cost(£100)                                  |
       |  3 | 151223/003 | £ 360.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£100) + disbursement vat(£20) + pc/cc vat(£40)                                                  |
-      |  4 | 151223/004 | £ 320.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£100) + disbursement vat(£20) + pc/cc vat(£40)                                                  |
       |  5 | 151223/005 | £ 360.00 | Priced at hourly rates (profit cost(£0) +  counsel cost(£100)) + disbursement amount(£100) + disbursement vat(£20) + pc/cc vat(£40) + DTW cost(£100)                                   |
-      |  6 | 151223/006 | £ 320.00 | Priced at hourly rates (profit cost(£0) +  counsel cost(£100)) + disbursement amount(£100) + disbursement vat(£20) + pc/cc vat(£0) + DTW cost(£100)                                    |
       |  7 | 151223/007 | £ 360.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£0) + disbursement vat(£60) + pc/cc vat(£0) + DTW cost(£100)                                    |
-      |  8 | 151223/008 | £ 300.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£0) + disbursement vat(£0) + pc/cc vat(£0) + DTW cost(£100)                                     |
       |  9 | 151223/009 | £ 340.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£100) + disbursement vat(£0) + pc/cc vat(£40) + DTW cost(£0)                                    |
-      | 10 | 151223/010 | £ 300.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£100) + disbursement vat(£0) + pc/cc vat(£0) + DTW cost(£0)                                     |
       | 11 | 151223/011 | £ 240.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£0) + disbursement vat(£0) + pc/cc vat(£40) + DTW cost(£0)                                      |
-      | 12 | 151223/012 | £ 200.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£0) + disbursement vat(£0) + pc/cc vat(£0) + DTW cost(£0)                                       |
       | 13 | 151223/013 | £ 100.00 | Priced at hourly rates (profit cost(£0) +  counsel cost(£0)) + disbursement amount(£100) + disbursement vat(£0) + pc/cc vat(£0) + DTW cost(£0)                                         |
-      | 14 | 151223/014 | £ 100.00 | Priced at hourly rates (profit cost(£0) +  counsel cost(£0)) + disbursement amount(£100) + disbursement vat(£0) + pc/cc vat(£0) + DTW cost(£0)                                         |
       | 15 | 151223/015 | £ 0.00   | Priced at hourly rates (profit cost(£0) +  counsel cost(£0)) + disbursement amount(£0) + disbursement vat(£0) + pc/cc vat(£0) + DTW cost(£0) ignores as PC and CC are zero(nil claims) |
-      | 16 | 151223/016 | £ 0.00   | Priced at hourly rates (profit cost(£0) +  counsel cost(£0)) + disbursement amount(£0) + disbursement vat(£0) + pc/cc vat(£0) + DTW cost(£0) ignores as PC and CC are zero(nil claims) |
       | 17 | 151223/017 | £ 240.00 | Priced at hourly rates (profit cost(£0) +  counsel cost(£100)) + disbursement amount(£0) + disbursement vat(£0) + pc/cc vat(£40) + DTW cost(£100)                                      |
-      | 18 | 151223/018 | £ 200.00 | Priced at hourly rates (profit cost(£0) +  counsel cost(£100)) + disbursement amount(£0) + disbursement vat(£0) + pc/cc vat(£0) + DTW cost(£100)                                       |
 
   Scenario: IAXL:IDAS pricing before start date 14 dec 2023. Testing pricing for effective date for DTW pricing.
     Given a test firm user is logged in CWA
@@ -65,14 +47,10 @@ Feature: Validation for Illegal Immigration Act
     And the following outcomes are bulkloaded:
       | # | CASE_ID | UFN        | CLAIM_TYPE | CASE_START_DATE | WORK_CONCLUDED_DATE | OUTCOME_CODE | TRAVEL_COSTS | PROFIT_COST | COUNSEL_COST | VAT_INDICATOR | DISBURSEMENTS_AMOUNT | DISBURSEMENTS_VAT | EXEMPTION_CRITERIA_SATISFIED |
       | 1 |     001 | 131223/001 | CM         |      13/12/2023 |          15/12/2023 | IX           |          100 |         100 |          100 | Y             |               100.00 |                20 | TR001                        |
-      | 2 |     002 | 131223/002 | SC         |      13/12/2023 |          15/12/2023 | --           |          100 |         100 |          100 | N             |               100.00 |                20 | TR001                        |
       | 3 |     003 | 131223/003 | CM         |      13/12/2023 |          15/12/2023 | IX           |          100 |           0 |            0 | Y             |               100.00 |                20 | TR001                        |
-      | 4 |     004 | 131223/004 | SC         |      13/12/2023 |          15/12/2023 | --           |          100 |           0 |            0 | N             |               100.00 |                20 | TR001                        |
     When user confirms the submission
     And user is on the pricing outcome details page
     Then user should see the following outcomes:
       | # | UFN        | Value    | Comment                                                                                                                                                                                                                                                       |
       | 1 | 131223/001 | £ 360.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£100) + disbursement vat(£20) + pc/cc vat(£40) + DTW cost(£100) ignores as code comnination does not price DTW prior to 14 dec in tst(effective date(01/01/24 in prod) |
-      | 2 | 131223/002 | £ 320.00 | Priced at hourly rates (profit cost(£100) +  counsel cost(£100)) + disbursement amount(£100) + disbursement vat(£20) + pc/cc vat(£0) + DTW cost(£100) ignores as code comnination does not price DTW prior to 14 dec in tst(effective date(01/01/24 in prod)  |
       | 3 | 131223/003 | £ 120.00 | Priced at hourly rates (profit cost(£0) +  counsel cost(£0)) + disbursement amount(£100) + disbursement vat(£20) + pc/cc vat(£0) + DTW cost(£100) ignores as code comnination does not price DTW prior to 14 dec in tst(effective date(01/01/24 in prod)      |
-      | 4 | 131223/004 | £ 120.00 | Priced at hourly rates (profit cost(£0) +  counsel cost(£0)) + disbursement amount(£100) + disbursement vat(£20) + pc/cc vat(£0) + DTW cost(£100) ignores as code comnination does not price DTW prior to 14 dec in tst(effective date(01/01/24 in prod)      |

--- a/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/dtw_validation.feature
+++ b/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/dtw_validation.feature
@@ -112,7 +112,7 @@ Feature: claims validations for DTW(detention travel and waiting cost) for follo
     Then the following results are expected:
       | # | ERROR_CODE_OR_MESSAGE |
       | 1 | <none>                |
-      | 2 | <none>                |
+      | 2 | The reporting code combination that has been used is not valid. Please amend accordingly. |
 
   Scenario: Add stage claim and completed matter with counsel cost zero and non zero values
     Given a test firm user is logged in CWA
@@ -126,4 +126,4 @@ Feature: claims validations for DTW(detention travel and waiting cost) for follo
     Then the following results are expected:
       | # | ERROR_CODE_OR_MESSAGE |
       | 1 | <none>                |
-      | 2 | <none>                |
+      | 2 | The reporting code combination that has been used is not valid. Please amend accordingly.  |

--- a/features/validations/legal_help/immigration_and_asylum/iaxl_idas_cm_manual.feature
+++ b/features/validations/legal_help/immigration_and_asylum/iaxl_idas_cm_manual.feature
@@ -1,0 +1,62 @@
+Feature: Validation for Immigration and Asylum claims with matter type IAXL:IDAS.
+
+  Background:
+    Given user is on their "LEGAL HELP" submission details page
+
+  @delete_outcome_after @manual_submission @valid @iaxl @idas
+  Scenario Outline: Add valid Immigration and Asylum claims using matter type IAXL:IDAS and completed matters, CM. Only outcome code IX is valid. 
+    When user adds outcomes for "Legal Help" "Immigration And Asylum" with fields like this:
+      | case_id | matter_type | case_start_date | claim_type | procurement_area | access_point | outcome_code  | irc_surgery |
+      |     001 | IAXL:IDAS   |        18/10/21 |   CM       |  PA00188         | AP00186      | IX            |    No       |  
+    Then the outcome saves successfully
+
+
+  @delete_outcome_after @manual_submission @invalid @iaxl @idas
+  Scenario Outline: Add invalid Immigration and Asylum claims using matter type IAXL:IDAS and completed matters, CM. Outcome code -- is not valid. 
+    When user adds outcomes for "Legal Help" "Immigration And Asylum" with fields like this:
+      | case_id | matter_type | case_start_date | claim_type | procurement_area | access_point | outcome_code  | irc_surgery |
+      |     002 | IAXL:IDAS   |        18/10/21 |   CM       |  PA00188         | AP00186      | --            |    No       |  
+    Then the outcome does not save and gives an error containing:
+      """
+      The reporting code combination that has been used is not valid. Please amend accordingly.
+      """
+
+  @delete_outcome_after @manual_submission @invalid @iaxl @idas
+  Scenario Outline: Add invalid Immigration and Asylum claims using matter type IAXL:IDAS and completed matters, CM. Outcome code IA is not valid. 
+    When user adds outcomes for "Legal Help" "Immigration And Asylum" with fields like this:
+      | case_id | matter_type | case_start_date | claim_type | procurement_area | access_point | outcome_code  | irc_surgery |  
+      |     003 | IAXL:IDAS   |        18/10/21 |   CM       |  PA00188         | AP00187      | IA            |    No       |
+    Then the outcome does not save and gives an error containing:
+      """
+      The reporting code combination that has been used is not valid. Please amend accordingly.
+      """
+
+  @delete_outcome_after @manual_submission @invalid @iaxl @idas
+  Scenario Outline: Add invalid Immigration and Asylum claims using matter type IAXL:IDAS and completed matters, CM. Outcome code ID is not valid. 
+    When user adds outcomes for "Legal Help" "Immigration And Asylum" with fields like this:
+      | case_id | matter_type | case_start_date | claim_type | procurement_area | access_point | outcome_code  | irc_surgery |  
+      |     004 | IAXL:IDAS   |        18/10/21 |   CM       |  PA00188         | AP00187      | ID            |    No       |
+    Then the outcome does not save and gives an error containing:
+      """
+      The reporting code combination that has been used is not valid. Please amend accordingly.
+      """
+
+  @delete_outcome_after @manual_submission @invalid @iaxl @idas
+  Scenario Outline: Add invalid Immigration and Asylum claims using matter type IAXL:IDAS and completed matters, CM. Outcome code IZ is not valid. 
+    When user adds outcomes for "Legal Help" "Immigration And Asylum" with fields like this:
+      | case_id | matter_type | case_start_date | claim_type | procurement_area | access_point | outcome_code  | irc_surgery |  
+      |     005 | IAXL:IDAS   |        18/10/21 |   CM       |  PA00188         | AP00187      | IZ            |    No       |
+    Then the outcome does not save and gives an error containing:
+      """
+      The reporting code combination that has been used is not valid. Please amend accordingly.
+      """
+ 
+  @delete_outcome_after @manual_submission @invalid @iaxl @idas
+  Scenario Outline: Add invalid Immigration and Asylum claims using matter type IAXL:IDAS and stage claim, SC which is not allowed. 
+    When user adds outcomes for "Legal Help" "Immigration" with fields like this:
+      | case_id | matter_type | case_start_date | claim_type | procurement_area | access_point | outcome_code  | 
+      |     006 | IAXL:IDAS   |        18/10/21 |   SC       |  PA00188         | AP00187      | --            |
+    Then the outcome does not save and gives an error containing:
+      """
+      The reporting code combination that has been used is not valid. Please amend accordingly.
+      """

--- a/features/validations/legal_help/immigration_and_asylum/iaxl_idas_cm_validation.feature
+++ b/features/validations/legal_help/immigration_and_asylum/iaxl_idas_cm_validation.feature
@@ -1,0 +1,65 @@
+Feature: Validation for Immigration and Asylum claims with matter type IAXL:IDAS.
+
+Scenario: Add valid outcome with matter type IAXL:IDAS and claim type CM and valid outcome code IX.
+    Given a test firm user is logged in CWA
+    And user prepares to submit outcomes for test provider "LEGAL HELP.IMMAS#12"
+    Given the following Matter Types are chosen:
+      | IAXL:IDAS |
+    And the following outcomes are bulkloaded:
+      | # | CASE_ID | UFN        | CLAIM_TYPE | CASE_START_DATE | WORK_CONCLUDED_DATE | OUTCOME_CODE | TRAVEL_COSTS | PROFIT_COST |
+      | 1 |     001 | 010423/001 | CM         |      01/04/2023 |          30/04/2023 | IX           |            0 |         100 |
+    Then the following results are expected:
+      | # | ERROR_CODE_OR_MESSAGE |
+      | 1 | <none>                |
+
+Scenario: Add invalid outcome with matter type IAXL:IDAS and claim type SC and outcome code --.
+    Given a test firm user is logged in CWA
+    And user prepares to submit outcomes for test provider "LEGAL HELP.IMMAS#12"
+    Given the following Matter Types are chosen:
+      | IAXL:IDAS |
+    And the following outcomes are bulkloaded:
+      | # | CASE_ID | UFN        | CLAIM_TYPE | CASE_START_DATE | WORK_CONCLUDED_DATE | OUTCOME_CODE | TRAVEL_COSTS | PROFIT_COST |
+      | 1 |     001 | 010423/001 | SC         |      01/04/2023 |          30/04/2023 | --           |            0 |         100 |
+    Then the following results are expected:
+      | # | ERROR_CODE_OR_MESSAGE |
+      | 1 | The reporting code combination that has been used is not valid. Please amend accordingly.|
+
+Scenario: Add invalid outcomes with matter type IAXL:IDAS and claim type CM and invalid outcome codes: -- IA IB IC ID IE IF IG IH IU IV IW IY IZ.
+    Given a test firm user is logged in CWA
+    And user prepares to submit outcomes for test provider "LEGAL HELP.IMMAS#12"
+    Given the following Matter Types are chosen:
+      | IAXL:IDAS |
+    And the following outcomes are bulkloaded:
+      | # | CASE_ID | UFN        | CLAIM_TYPE | CASE_START_DATE | WORK_CONCLUDED_DATE | OUTCOME_CODE | TRAVEL_COSTS | PROFIT_COST | EXEMPTION_CRITERIA_SATISFIED |
+      | 1 |     001 | 151223/001 | CM         |      15/12/2023 |          15/12/2023 | --           |            1 |         100 | TR001                        |
+      | 2 |     002 | 151223/002 | CM         |      15/12/2023 |          15/12/2023 | IA           |            1 |         100 | TR001                        |
+      | 3 |     003 | 151223/003 | CM         |      15/12/2023 |          15/12/2023 | IB           |            1 |         100 | TR001                        |
+      | 4 |     004 | 151223/004 | CM         |      15/12/2023 |          15/12/2023 | IC           |            1 |         100 | TR001                        |
+      | 5 |     005 | 151223/005 | CM         |      15/12/2023 |          15/12/2023 | ID           |            1 |         100 | TR001                        |
+      | 6 |     006 | 151223/006 | CM         |      15/12/2023 |          15/12/2023 | IE           |            1 |         100 | TR001                        |
+      | 7 |     007 | 151223/007 | CM         |      15/12/2023 |          15/12/2023 | IF           |            1 |         100 | TR001                        |
+      | 8 |     008 | 151223/008 | CM         |      15/12/2023 |          15/12/2023 | IG           |            1 |         100 | TR001                        |
+      | 9 |     009 | 151223/009 | CM         |      15/12/2023 |          15/12/2023 | IH           |            1 |         100 | TR001                        |
+      | 10 |    010 | 151223/010 | CM         |      15/12/2023 |          15/12/2023 | IU           |            1 |         100 | TR001                        |
+      | 11 |    011 | 151223/011 | CM         |      15/12/2023 |          15/12/2023 | IV           |            1 |         100 | TR001                        |
+      | 12 |    012 | 151223/012 | CM         |      15/12/2023 |          15/12/2023 | IW           |            1 |         100 | TR001                        |
+      | 13 |    013 | 151223/013 | CM         |      15/12/2023 |          15/12/2023 | IY           |            1 |         100 | TR001                        |
+      | 14 |    014 | 151223/014 | CM         |      15/12/2023 |          15/12/2023 | IZ           |            1 |         100 | TR001                        |
+
+    Then the following results are expected:
+      | # | ERROR_CODE_OR_MESSAGE |
+      | 1 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 2 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 3 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 4 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 5 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 6 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 7 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 8 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 9 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 10 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 11 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 12 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 13 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      | 14 | The reporting code combination that has been used is not valid. Please amend accordingly. |
+      


### PR DESCRIPTION
## What does this pull request do?

This PR is for 2 new feature tests to test for the validation change for mt code IAXL:IDAS to be available only for Completed matters and with outcome code IX.

It also modifies two existing feature tests to allow for the new business rule.

## Why make these changes?

These changes are necessary for testing the implementation of the new business rule.

## Checklist

- [ ] Provided link to a JIRA ticket: https://dsdmoj.atlassian.net/browse/TA-3080
