### PR TITLE
chore: change target namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       environment:
         description: Destination environment
         type: string
-        default: laa-cwa-feature-tests
+        default: laa-cwa-feature-tests-dev
       token:
         description: CircleCI Service account token
         type: string
@@ -51,8 +51,8 @@ jobs:
             -f charts/cwa-tests/Values.yaml \
             --set ecr.image.tag=${SANITISED_BRANCH_WITH_SHA} \
             --wait --timeout 300s
-            export POD_NAME=$(kubectl get pods -n laa-cwa-feature-tests --no-headers | awk '{print $1}' | grep '^cwa-tests-[0-9]\{10\}$' | sort | tail -1)
-            kubectl logs -f -n laa-cwa-feature-tests $POD_NAME
+            export POD_NAME=$(kubectl get pods -n laa-cwa-feature-tests-dev --no-headers | awk '{print $1}' | grep '^cwa-tests-[0-9]\{10\}$' | sort | tail -1)
+            kubectl logs -f -n laa-cwa-feature-tests-dev $POD_NAME
       - run:
           name: Creating Artifacts folder
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       environment:
         description: Destination environment
         type: string
-        default: laa-cwa-test
+        default: laa-cwa-feature-tests
       token:
         description: CircleCI Service account token
         type: string
@@ -51,8 +51,8 @@ jobs:
             -f charts/cwa-tests/Values.yaml \
             --set ecr.image.tag=${SANITISED_BRANCH_WITH_SHA} \
             --wait --timeout 300s
-            export POD_NAME=$(kubectl get pods -n laa-cwa-test --no-headers | awk '{print $1}' | grep '^cwa-tests-[0-9]\{10\}$' | sort | tail -1)
-            kubectl logs -f -n laa-cwa-test $POD_NAME
+            export POD_NAME=$(kubectl get pods -n laa-cwa-feature-tests --no-headers | awk '{print $1}' | grep '^cwa-tests-[0-9]\{10\}$' | sort | tail -1)
+            kubectl logs -f -n laa-cwa-feature-tests $POD_NAME
       - run:
           name: Creating Artifacts folder
           command: |


### PR DESCRIPTION
## What does this pull request do?

- Reconfigured circleci config to deploy to kubernetes namespace `laa-cwa-feature-tests-dev`, migrating from `laa-cwa-test`

## Why make these changes?

- Bringing namespace naming convention in line and allow for future expansion

## Checklist

- [https://dsdmoj.atlassian.net/browse/CC-3274?atlOrigin=eyJpIjoiOTkyZjU5MTA2ZDI2NDcwNjk0M2E0OWI1YThjOGNkM2MiLCJwIjoiaiJ9]
