### PR TITLE
fix: correct k8s sa in helmchart

### DIFF
--- a/charts/cwa-tests/Values.yaml
+++ b/charts/cwa-tests/Values.yaml
@@ -2,7 +2,7 @@ global:
   branch: main
   costcentre: LAA
   namespace: "laa-cwa-test"
-  serviceAccount: "sa-laa-cwa-test"
+  serviceAccount: "irsa-s3-laa-cwa-feature-tests-dev"
   browser: chrome
   test_env: tst
 


### PR DESCRIPTION
## What does this pull request do?

- Modify helm chart values to use a new IRSA service account

## Why make these changes?

- Migration to new k8s namespace

## Checklist

- `https://dsdmoj.atlassian.net/browse/CC-3274?atlOrigin=eyJpIjoiNWQ4M2Q5NmI1MTZjNDhmNGIzYmI4ODkxY2IyODExZGYiLCJwIjoiaiJ9`
