### PR TITLE
skip all IMA related tests as the code is disabled

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,4 +1,4 @@
-default: --publish-quiet --format pretty --format Cucumber::Formatter::HTML --out reports/cucumber_report.html 
+default: --publish-quiet --format pretty --format Cucumber::Formatter::HTML --out reports/cucumber_report.html  --tags 'not @skip'
 # default:  --publish-quiet
 # html_report: --publish-quiet --format pretty  --format html --out reports/<%= Time.now.strftime("%d-%m-%y_%H:%M")%>-report.html
 # html_report: --publish-quiet --format pretty  --format html --out reports/report.html  This is not working in circle ci 

--- a/features/pricing/legal_help/immigration/Illegal_migration_act/IMMA.feature
+++ b/features/pricing/legal_help/immigration/Illegal_migration_act/IMMA.feature
@@ -1,3 +1,4 @@
+@skip
 Feature: Pricing: IMMA: Illegal Immigration Act
 
   Background: 

--- a/features/pricing/legal_help/immigration/Illegal_migration_act/IMMA_Misc.feature
+++ b/features/pricing/legal_help/immigration/Illegal_migration_act/IMMA_Misc.feature
@@ -1,3 +1,4 @@
+@skip
 Feature: Pricing: IMMA: Illegal Immigration Act pricing tests for counsel cost error, DB limits and PC limits with prior authority number and without prior authority number
 
   Background: 

--- a/features/pricing/legal_help/immigration/Illegal_migration_act/accumulated_pricing.feature
+++ b/features/pricing/legal_help/immigration/Illegal_migration_act/accumulated_pricing.feature
@@ -1,3 +1,4 @@
+@skip
 Feature: Pricing: IMMA: Illegal Immigration Act
 
   Background: 

--- a/features/pricing/legal_help/immigration/Illegal_migration_act/dtw_pricing.feature
+++ b/features/pricing/legal_help/immigration/Illegal_migration_act/dtw_pricing.feature
@@ -1,3 +1,4 @@
+@skip
 Feature: Validation for Illegal Immigration Act
 
   Scenario Outline: IAXL:IDAS pricing before start date 14 dec 2023. Testing pricing for effective date for DTW pricing.

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -18,7 +18,7 @@ Capybara.register_driver :firefox do |app|
   options = Selenium::WebDriver::Options.firefox(
     accept_insecure_certs: true
   )
-  options = Selenium::WebDriver::Firefox::Options.new()
+  options = Selenium::WebDriver::Firefox::Options.new
   options.add_argument('--headless') if ENV['HEADLESS'] == 'true'
   options.add_argument('--incognito')
   Capybara::Selenium::Driver.new(
@@ -30,6 +30,5 @@ end
 
 Capybara.default_driver = :firefox
 Capybara.default_max_wait_time = 5
-Capybara.current_window.resize_to(1920,1080)
 
 World(PortalEnv, CWAProvider)

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -4,6 +4,10 @@ require_relative '../pages/outcome_page.rb'
 include OutcomePage
 
 Before do
+  Capybara.current_window.resize_to(1920, 1080)
+end
+
+Before do
   @start_time = Time.now
   acknowledge_certificate if ENV['TEST_ENV'] == 'uat' && !defined?($acknowledged_cert)
   logout_from_cwa_and_portal

--- a/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/IMMA_bulk_duplicate_claims.feature
+++ b/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/IMMA_bulk_duplicate_claims.feature
@@ -1,4 +1,4 @@
-@bulkload
+@skip @bulkload
 Feature: duplicate claims validations for Illegal migration act
 1-11 same UFN, UCN   12-14 different UCN IMA codes   15-17 IMA to other code combo same UCN  18-21 other code to IMA code same UCN  22-24  other code to IMA code different UCN
 

--- a/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/IMMA_manual_duplicate_claims.feature
+++ b/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/IMMA_manual_duplicate_claims.feature
@@ -1,3 +1,4 @@
+@skip
 Feature: Validation for Illegal Immigration Act for duplicate claims for manual submission
 
   Background: 

--- a/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/Illegal_migration_act.feature
+++ b/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/Illegal_migration_act.feature
@@ -1,3 +1,4 @@
+@skip
 Feature: Validation for Illegal Immigration Act
 
   Background: 

--- a/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/Illegal_migration_act_bulk_misc.feature
+++ b/features/validations/legal_help/immigration_and_asylum/Illegal_migration_act/Illegal_migration_act_bulk_misc.feature
@@ -1,3 +1,4 @@
+@skip
 Feature: claims validations for Illegal migration act miscllaneous
 
   Background: 

--- a/features/validations/legal_help/immigration_and_asylum/claim_type_validation.feature
+++ b/features/validations/legal_help/immigration_and_asylum/claim_type_validation.feature
@@ -3,7 +3,8 @@ Feature: claim type validations for Immigration and Asylum
   Background: 
     Given a test firm user is logged in CWA
     And user prepares to submit outcomes for test provider "LEGAL HELP.IMMOT#4"
-
+  
+  @skip
   Scenario: Add null and miscllaneous claim type
     Given the following Matter Types are chosen:
       | IMMA:IMRN |


### PR DESCRIPTION
## What does this pull request do?

Skip all IMA tests from running as part of the test pack

## Why make these changes?

The Illegal migration act is shelved and as such IMMA:IMRN code combination is disabled. so these tests need to be skipped for the time being, until we decide to remove the complete IMA code and decide to remove these tests. 

## Checklist

part of ticket https://dsdmoj.atlassian.net/browse/TA-3218